### PR TITLE
Bug fix: Respect externals options in library plugin

### DIFF
--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -14,6 +14,7 @@ module.exports = (neutrino, opts = {}) => {
     target: 'web',
     libraryTarget: 'umd',
     babel: {},
+    externals: opts.externals !== false && {},
     clean: opts.clean !== false && {
       paths: [neutrino.options.output]
     }
@@ -56,7 +57,7 @@ module.exports = (neutrino, opts = {}) => {
   neutrino.config
     .when(hasSourceMap, () => neutrino.use(banner))
     .devtool('source-map')
-    .externals([nodeExternals()])
+    .externals([nodeExternals(options.externals)])
     .target(options.target)
     .context(neutrino.options.root)
     .output


### PR DESCRIPTION
Previously, externals was ignored. This passes along
the options to webpack-node-externals.

Fixes #987 

I verified that this fix in a project I was working on. Without this change, `externals.whitelist` had no effect. With this change, whitelisted modules get bundled into the output file.