### PR TITLE
[v8.x] Fix Babel minification documentation

### DIFF
--- a/docs/packages/web/README.md
+++ b/docs/packages/web/README.md
@@ -287,7 +287,7 @@ module.exports = {
             removeConsole: true,
             removeDebugger: true,
           },
-          preset: {}
+          plugin: {}
         }
       },
 

--- a/docs/packages/web/README.md
+++ b/docs/packages/web/README.md
@@ -283,8 +283,11 @@ module.exports = {
       // Example: Remove console and debugger from output
       minify: {
         babel: {
-          removeConsole: true,
-          removeDebugger: true,
+          minify: {
+            removeConsole: true,
+            removeDebugger: true,
+          },
+          preset: {}
         }
       },
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -283,8 +283,11 @@ module.exports = {
       // Example: Remove console and debugger from output
       minify: {
         babel: {
-          removeConsole: true,
-          removeDebugger: true,
+          minify: {
+            removeConsole: true,
+            removeDebugger: true,
+          },
+          plugin: {}
         }
       },
 


### PR DESCRIPTION
When using the `react-components` preset, I wanted to not minify class names and spent quite a bit of time following code trails to find out that the documentation actually appears to be incorrect with regard to Babel minification options.

Looks like all we need is just an extra `minify` level, and with that change the configuration started working for me in local tests on version 8.

I also targeted this toward version 8 rather than master because it appears the minification configuration is changed a lot in master.