### PR TITLE
Fix respecting externals options in library middleware

### DIFF
--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -14,6 +14,7 @@ module.exports = (neutrino, opts = {}) => {
     target: 'web',
     libraryTarget: 'umd',
     babel: {},
+    externals: opts.externals !== false && {},
     clean: opts.clean !== false && {
       paths: [neutrino.options.output]
     }
@@ -53,6 +54,7 @@ module.exports = (neutrino, opts = {}) => {
   );
 
   neutrino.config
+    .when(options.externals, config => config.externals([nodeExternals(options.externals)]))
     .when(hasSourceMap, () => neutrino.use(banner))
     .devtool('source-map')
     .externals([nodeExternals()])


### PR DESCRIPTION
From #999, hat-tip to @sloria

---

Previously, externals was ignored. This passes along
the options to webpack-node-externals.

Fixes #987 

I verified that this fix in a project I was working on. Without this change, `externals.whitelist` had no effect. With this change, whitelisted modules get bundled into the output file.