### PR TITLE
Docs: Add a Content-Security-Policy and other best practices

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
 mkdocs==1.0.2
+# When updating the theme, check the Netlify PR preview to see if any changes
+# are required to the Content-Security-Policy header in netlify.toml.
 mkdocs-material==3.0.3
 Pygments==2.2.0

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,28 @@
   publish = "build"
   command = "../scripts/build-docs.sh"
 
+[[headers]]
+  # Implement security recommendations from:
+  # https://infosec.mozilla.org/guidelines/web_security
+  for = "/*"
+  [headers.values]
+    # The CSP was generated with the help of:
+    # https://addons.mozilla.org/en-US/firefox/addon/laboratory-by-mozilla/
+    # The GitHub API and Google Fonts domains are needed for the Material theme.
+    # The Travis and Shields.io domains are required for our badge images.
+    Content-Security-Policy = """
+        default-src 'none';
+        connect-src 'self' https://api.github.com;
+        font-src 'self' https://fonts.gstatic.com;
+        img-src 'self' https://api.travis-ci.org https://img.shields.io;
+        script-src 'self';
+        style-src 'self' https://fonts.googleapis.com;
+        frame-ancestors 'none';
+    """
+    X-Content-Type-Options = "nosniff"
+    X-Frame-Options = "DENY"
+    X-XSS-Protection = "1; mode=block"
+
 # Redirect domain aliases to the primary domain.
 
 [[redirects]]


### PR DESCRIPTION
This implements the recommendations from:
https://infosec.mozilla.org/guidelines/web_security

Which raises the grade given by https://observatory.mozilla.org/ from a `D` to an `A+`:
https://observatory.mozilla.org/analyze/neutrinojs.org
https://observatory.mozilla.org/analyze/master.neutrinojs.org

The headers are configured according to:
https://www.netlify.com/docs/headers-and-basic-auth/#structured-configuration
https://github.com/toml-lang/toml#string