### PR TITLE
html-template: Replace html-webpack-template with our own template

### DIFF
--- a/packages/html-template/README.md
+++ b/packages/html-template/README.md
@@ -35,16 +35,20 @@ and plug it into Neutrino:
 
 ```js
 // Using function middleware format
-const template = require('@neutrinojs/html-template');
 
 // Usage shows default values
-// Accepts options specified by HtmlWebpackTemplate
-// https://github.com/jaketrent/html-webpack-template
+// Accepts options specified by html-webpack-plugin:
+// https://github.com/jantimon/html-webpack-plugin#configuration
 neutrino.use(template, {
-  inject: false,
+  // @neutrinojs/html-template includes a custom template that has more features
+  // (eg appMountId and lang support) than the default html-webpack-plugin template:
+  // https://github.com/jantimon/html-webpack-plugin/blob/master/default_index.ejs
+  template: require.resolve('@neutrinojs/html-template/template.ejs'),
   appMountId: 'root',
-  xhtml: true,
-  mobile: true,
+  lang: 'en',
+  meta: {
+    viewport: 'width=device-width, initial-scale=1'
+  },
   minify: {
     useShortDoctype: true,
     keepClosingSlash: true,
@@ -65,15 +69,20 @@ neutrino.use(template, {
 // Using object or array middleware format
 
 // Usage shows default values
-// Accepts options specified by HtmlWebpackTemplate
-// https://github.com/jaketrent/html-webpack-template
+// Accepts options specified by html-webpack-plugin:
+// https://github.com/jantimon/html-webpack-plugin#configuration
 module.exports = {
   use: [
     ['@neutrinojs/html-template', {
-      inject: false,
+      // @neutrinojs/html-template includes a custom template that has more features
+      // (eg appMountId and lang support) than the default html-webpack-plugin template:
+      // https://github.com/jantimon/html-webpack-plugin/blob/master/default_index.ejs
+      template: require.resolve('@neutrinojs/html-template/template.ejs'),
       appMountId: 'root',
-      xhtml: true,
-      mobile: true,
+      lang: 'en',
+      meta: {
+        viewport: 'width=device-width, initial-scale=1'
+      },
       minify: {
         useShortDoctype: true,
         keepClosingSlash: true,

--- a/packages/html-template/index.js
+++ b/packages/html-template/index.js
@@ -1,5 +1,6 @@
+const { resolve } = require('path');
+
 const HtmlPlugin = require('html-webpack-plugin');
-const template = require('html-webpack-template');
 const merge = require('deepmerge');
 
 module.exports = (neutrino, { pluginId = 'html', ...options } = {}) => {
@@ -7,11 +8,14 @@ module.exports = (neutrino, { pluginId = 'html', ...options } = {}) => {
     .plugin(pluginId)
     .use(HtmlPlugin, [
       merge({
-        template,
-        inject: false,
+        // Use a custom template that has more features (appMountId, lang) than the default:
+        // https://github.com/jantimon/html-webpack-plugin/blob/master/default_index.ejs
+        template: resolve(__dirname, 'template.ejs'),
         appMountId: 'root',
-        xhtml: true,
-        mobile: true,
+        lang: 'en',
+        meta: {
+          viewport: 'width=device-width, initial-scale=1'
+        },
         minify: {
           useShortDoctype: true,
           keepClosingSlash: true,

--- a/packages/html-template/package.json
+++ b/packages/html-template/package.json
@@ -24,8 +24,7 @@
   },
   "dependencies": {
     "deepmerge": "^1.5.2",
-    "html-webpack-plugin": "^3.2.0",
-    "html-webpack-template": "^6.2.0"
+    "html-webpack-plugin": "^3.2.0"
   },
   "peerDependencies": {
     "neutrino": "^9.0.0-0",

--- a/packages/html-template/template.ejs
+++ b/packages/html-template/template.ejs
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="<%= htmlWebpackPlugin.options.lang %>">
+  <head>
+    <meta charset="utf-8">
+    <title><%= htmlWebpackPlugin.options.title %></title>
+  </head>
+  <body>
+    <div id="<%= htmlWebpackPlugin.options.appMountId %>"></div>
+  </body>
+</html>

--- a/packages/web/test/web_test.js
+++ b/packages/web/test/web_test.js
@@ -1,5 +1,8 @@
+import { resolve } from 'path';
+
 import test from 'ava';
 import { validate } from 'webpack';
+
 import Neutrino from '../../neutrino/Neutrino';
 
 const mw = () => require('..');
@@ -117,18 +120,21 @@ test('supports multiple mains with custom html-webpack-plugin options', t => {
 
   api.use(mw(), { html: { title: 'Default Title', minify: false } });
 
+  const templatePath = resolve(__dirname, '../../html-template/template.ejs');
+
   t.deepEqual(api.config.plugin('html-index').get('args'), [{
     appMountId: 'root',
     chunks: [
       'index'
     ],
     filename: 'index.html',
-    inject: false,
+    lang: 'en',
+    meta: {
+      viewport: 'width=device-width, initial-scale=1'
+    },
     minify: false,
-    mobile: true,
-    template: require('html-webpack-template'),
-    title: 'Default Title',
-    xhtml: true
+    template: templatePath,
+    title: 'Default Title'
   }]);
 
   t.deepEqual(api.config.plugin('html-admin').get('args'), [{
@@ -137,12 +143,13 @@ test('supports multiple mains with custom html-webpack-plugin options', t => {
       'admin'
     ],
     filename: 'admin.html',
-    inject: false,
+    lang: 'en',
+    meta: {
+      viewport: 'width=device-width, initial-scale=1'
+    },
     minify: false,
-    mobile: true,
-    template: require('html-webpack-template'),
-    title: 'Admin Dashboard',
-    xhtml: true
+    template: templatePath,
+    title: 'Admin Dashboard'
   }]);
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5597,10 +5597,6 @@ html-webpack-plugin@^3.2.0:
     toposort "^1.0.0"
     util.promisify "1.0.0"
 
-html-webpack-template@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/html-webpack-template/-/html-webpack-template-6.2.0.tgz#3c9f15f616f4500927909d34adfbccb20d37943c"
-
 htmlparser2@^3.9.1, htmlparser2@^3.9.2:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"


### PR DESCRIPTION
The HTML template that comes with `html-webpack-plugin` [1] is very minimal and so until now we've used the more fully-featured template from `html-webpack-template` [2] instead.

However that template currently reimplements the core functionality of `html-webpack-plugin` in template markup and so has to be used with `inject` mode disabled [3]. This means:
- many `html-webpack-plugin` plugins don't work (eg the one for SRI)
- the template depends much more strongly on the internal data structures of `html-webpack-plugin`, and so can be broken by new major versions (as will be the case with `html-webpack-plugin` v4)
- the template doesn't benefit from upstream improvements made to the injected content.

In addition, `html-webpack-plugin` now supports several features that were previously only possible with a custom template (eg additional meta tags), and there are now many third party plugins to provide additional functionality (and are the preferred approach).

As such, this switches `@neutrinojs/html-template` to using its own custom template, that is virtually the same as [1], other than adding `lang` and `appMountId` support. The `mobile` option has been replaced by adding the same viewport tag via the new `meta` option.

If there are features that `html-webpack-template` supported, that our new simpler template does not, users can use their own template (`html-webpack-plugin` pushes this approach strongly) - Neutrino should cater for the 80% out of the box, not the 99%).

Unrelated to the switch away from `html-webpack-template`, I've also stopped setting `xhtml` to `true`, since XHTML compliant output isn't something that most people need.

[1] https://github.com/jantimon/html-webpack-plugin/blob/master/default_index.ejs
[2] https://github.com/jaketrent/html-webpack-template/blob/master/index.ejs
[3] https://github.com/jaketrent/html-webpack-template/issues/61