### PR TITLE
create-project: Update webpack-cli from v2 to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "verdaccio": "^3.0.2",
     "verdaccio-memory": "^1.0.1",
     "webpack": "^4.8.3",
+    "webpack-cli": "^3.1.0",
     "webpack-dev-server": "^3.1.4"
   },
   "lint-staged": {

--- a/packages/create-project/commands/init/matrix.js
+++ b/packages/create-project/commands/init/matrix.js
@@ -19,7 +19,7 @@ const STANDARDJS = '@neutrinojs/standardjs';
 
 const ESLINT = 'eslint@^5';
 const WEBPACK = 'webpack@^4';
-const WEBPACK_CLI = 'webpack-cli@^2';
+const WEBPACK_CLI = 'webpack-cli@^3';
 const WEBPACK_DEV_SERVER = 'webpack-dev-server@^3';
 
 const presets = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3900,7 +3900,7 @@ engine.io@~3.2.0:
     engine.io-parser "~2.1.0"
     ws "~3.3.1"
 
-enhanced-resolve@^4.1.0:
+enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz#41c7e0bfdfe74ac1ffe1e57ad6a5c6c9f3742a7f"
   dependencies:
@@ -5169,6 +5169,10 @@ global-dirs@^0.1.0:
   dependencies:
     ini "^1.3.4"
 
+global-modules-path@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/global-modules-path/-/global-modules-path-2.3.0.tgz#b0e2bac6beac39745f7db5c59d26a36a0b94f7dc"
+
 global@4.3.2, global@^4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
@@ -5923,7 +5927,7 @@ internal-ip@^3.0.1:
     default-gateway "^2.6.0"
     ipaddr.js "^1.5.2"
 
-interpret@^1.0.0:
+interpret@^1.0.0, interpret@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
@@ -11825,6 +11829,10 @@ uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
+v8-compile-cache@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz#a428b28bb26790734c4fc8bc9fa106fccebf6a6c"
+
 vali-date@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/vali-date/-/vali-date-1.0.0.tgz#1b904a59609fb328ef078138420934f6b86709a6"
@@ -12121,6 +12129,22 @@ webpack-chain@^4.8.0:
   dependencies:
     deepmerge "^1.5.2"
     javascript-stringify "^1.6.0"
+
+webpack-cli@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.1.0.tgz#d71a83687dcfeb758fdceeb0fe042f96bcf62994"
+  dependencies:
+    chalk "^2.4.1"
+    cross-spawn "^6.0.5"
+    enhanced-resolve "^4.0.0"
+    global-modules-path "^2.1.0"
+    import-local "^1.0.0"
+    inquirer "^6.0.0"
+    interpret "^1.1.0"
+    loader-utils "^1.1.0"
+    supports-color "^5.4.0"
+    v8-compile-cache "^2.0.0"
+    yargs "^12.0.1"
 
 webpack-dev-middleware@3.2.0, webpack-dev-middleware@^3.0.1:
   version "3.2.0"
@@ -12440,7 +12464,7 @@ yargs-parser@^9.0.2:
   dependencies:
     camelcase "^4.1.0"
 
-yargs@12.0.1, yargs@^12.0.0:
+yargs@12.0.1, yargs@^12.0.0, yargs@^12.0.1:
   version "12.0.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.1.tgz#6432e56123bb4e7c3562115401e98374060261c2"
   dependencies:


### PR DESCRIPTION
We hadn't received a Renovate PR for this `webpack-cli` release (which would have reminded us to bump the version in `matrix.js`), since the dependency is intentionally not listed in `peerDependencies` so that people can install their own choice of CLI if desired. To prevent this problem in the future, `webpack-cli` has now been added to the monorepo `devDependencies`, so we'll get the reminder PR next time.

https://github.com/webpack/webpack-cli/compare/v2.1.5...v.3.1.0