### PR TITLE
Add devtool option to web preset

### DIFF
--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -23,7 +23,7 @@ module.exports = (neutrino, opts = {}) => {
     html: {},
     devtool: {
       development: 'cheap-module-eval-source-map',
-      production: false,
+      production: undefined,
       test: 'source-map'
     },
     devServer: {
@@ -113,12 +113,10 @@ module.exports = (neutrino, opts = {}) => {
       .use(EnvironmentPlugin, [options.env]);
   }
 
-  if (options.devtool) {
-    const devtool = options.devtool[process.env.NODE_ENV];
+  const devtool = options.devtool[process.env.NODE_ENV];
 
-    if (devtool) {
-      neutrino.config.devtool(devtool);
-    }
+  if (devtool !== undefined) {
+    neutrino.config.devtool(devtool);
   }
 
   neutrino.use(htmlLoader);

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -21,6 +21,11 @@ module.exports = (neutrino, opts = {}) => {
     env: false,
     hot: true,
     html: {},
+    devtool: {
+      development: 'cheap-module-eval-source-map',
+      production: false,
+      test: 'source-map'
+    },
     devServer: {
       hot: opts.hot !== false,
       publicPath: resolve('/', publicPath)
@@ -52,6 +57,14 @@ module.exports = (neutrino, opts = {}) => {
 
   if ('style' in options.minify) {
     throw new Error('The minify.style option has been removed. To enable style minification use the @neutrinojs/style-minify preset.');
+  }
+
+  if (typeof options.devtool === 'string' || typeof options.devtool === 'boolean') {
+    options.devtool = {
+      development: options.devtool,
+      production: options.devtool,
+      test: options.devtool
+    };
   }
 
   if (typeof options.devServer.proxy === 'string') {
@@ -98,6 +111,14 @@ module.exports = (neutrino, opts = {}) => {
   if (options.env) {
     neutrino.config.plugin('env')
       .use(EnvironmentPlugin, [options.env]);
+  }
+
+  if (options.devtool) {
+    const devtool = options.devtool[process.env.NODE_ENV];
+
+    if (devtool) {
+      neutrino.config.devtool(devtool);
+    }
   }
 
   neutrino.use(htmlLoader);
@@ -198,8 +219,6 @@ module.exports = (neutrino, opts = {}) => {
     })
     .when(process.env.NODE_ENV === 'development', config => {
       neutrino.use(devServer, options.devServer);
-      // TODO: Enable sourcemaps for NODE_ENV=test too?
-      config.devtool('cheap-module-eval-source-map');
       config.when(options.hot, (config) => {
         config.plugin('hot').use(HotModuleReplacementPlugin);
 

--- a/packages/web/test/web_test.js
+++ b/packages/web/test/web_test.js
@@ -92,6 +92,72 @@ test('valid preset test', t => {
   t.is(errors.length, 0);
 });
 
+test('devtool string option production', t => {
+  process.env.NODE_ENV = 'production';
+  const api = new Neutrino();
+  api.use(mw(), { devtool: 'source-map' });
+  const config = api.config.toConfig();
+
+  t.is(config.devtool, 'source-map');
+});
+
+test('devtool object option production', t => {
+  process.env.NODE_ENV = 'production';
+  const api = new Neutrino();
+  api.use(mw(), {
+    devtool: {
+      production: 'source-map'
+    }
+  });
+  const config = api.config.toConfig();
+
+  t.is(config.devtool, 'source-map');
+});
+
+test('devtool string option development', t => {
+  process.env.NODE_ENV = 'development';
+  const api = new Neutrino();
+  api.use(mw(), { devtool: 'source-map' });
+  const config = api.config.toConfig();
+
+  t.is(config.devtool, 'source-map');
+});
+
+test('devtool object option development', t => {
+  process.env.NODE_ENV = 'development';
+  const api = new Neutrino();
+  api.use(mw(), {
+    devtool: {
+      development: 'source-map'
+    }
+  });
+  const config = api.config.toConfig();
+
+  t.is(config.devtool, 'source-map');
+});
+
+test('devtool string option test', t => {
+  process.env.NODE_ENV = 'test';
+  const api = new Neutrino();
+  api.use(mw(), { devtool: 'cheap-eval-source-map' });
+  const config = api.config.toConfig();
+
+  t.is(config.devtool, 'cheap-eval-source-map');
+});
+
+test('devtool object option test', t => {
+  process.env.NODE_ENV = 'test';
+  const api = new Neutrino();
+  api.use(mw(), {
+    devtool: {
+      test: 'cheap-eval-source-map'
+    }
+  });
+  const config = api.config.toConfig();
+
+  t.is(config.devtool, 'cheap-eval-source-map');
+});
+
 test('supports env option using array form', t => {
   const api = new Neutrino();
 

--- a/packages/web/test/web_test.js
+++ b/packages/web/test/web_test.js
@@ -85,7 +85,7 @@ test('valid preset test', t => {
   // NODE_ENV/command specific
   t.false(config.optimization.minimize);
   t.true(config.optimization.splitChunks.name);
-  t.is(config.devtool, undefined);
+  t.is(config.devtool, 'source-map');
   t.is(config.devServer, undefined);
 
   const errors = validate(config);


### PR DESCRIPTION
Fixes #676.

I will update the docs for this once we are good with the approach, unless you would like to hold off due to the in-progress docs updates.

This option can be used like so:

```js
// disable for all environments
['@neutrinojs/web', {
  devtool: false
}]

// use the same value for all environments
['@neutrinojs/web', {
  devtool: 'source-map'
}]

// change per NODE_ENV
['@neutrinojs/web', {
  devtool: {
    development: 'cheap-module-eval-source-map',
    production: 'source-map',
    test: 'cheap-eval-source-map'
  }
}]
```