### PR TITLE
Added .web.js{x} resolve extensions to webpack for better react-native-web support

### DIFF
--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -50,4 +50,7 @@ module.exports = (neutrino, opts = {}) => {
   });
 
   neutrino.config.resolve.alias.set('react-native', 'react-native-web');
+
+  neutrino.config.resolve.extensions.prepend('.web.js');
+  neutrino.config.resolve.extensions.prepend('.web.jsx');
 };

--- a/packages/react/test/react_test.js
+++ b/packages/react/test/react_test.js
@@ -3,6 +3,7 @@ import { validate } from 'webpack';
 import Neutrino from '../../neutrino/Neutrino';
 
 const mw = () => require('..');
+const newExtensions = ['.web.jsx', '.web.js'];
 const originalNodeEnv = process.env.NODE_ENV;
 
 test.afterEach(() => {
@@ -22,9 +23,12 @@ test('valid preset production', t => {
   process.env.NODE_ENV = 'production';
   const api = new Neutrino();
   api.use(mw());
+  const config = api.config.toConfig();
 
-  const errors = validate(api.config.toConfig());
+  // Common
+  t.deepEqual(config.resolve.extensions.slice(0, 2), newExtensions);
 
+  const errors = validate(config);
   t.is(errors.length, 0);
 });
 
@@ -32,8 +36,24 @@ test('valid preset development', t => {
   process.env.NODE_ENV = 'development';
   const api = new Neutrino();
   api.use(mw());
+  const config = api.config.toConfig();
 
-  const errors = validate(api.config.toConfig());
+  // Common
+  t.deepEqual(config.resolve.extensions.slice(0, 2), newExtensions);
 
+  const errors = validate(config);
+  t.is(errors.length, 0);
+});
+
+test('valid preset test', t => {
+  process.env.NODE_ENV = 'test';
+  const api = new Neutrino();
+  api.use(mw());
+  const config = api.config.toConfig();
+
+  // Common
+  t.deepEqual(config.resolve.extensions.slice(0, 2), newExtensions);
+
+  const errors = validate(config);
   t.is(errors.length, 0);
 });

--- a/packages/react/test/react_test.js
+++ b/packages/react/test/react_test.js
@@ -26,7 +26,7 @@ test('valid preset production', t => {
   const config = api.config.toConfig();
 
   // Common
-  t.deepEqual(config.resolve.extensions.slice(0, 2), newExtensions);
+  t.deepEqual(config.resolve.extensions.slice(0, newExtensions.length), newExtensions);
 
   const errors = validate(config);
   t.is(errors.length, 0);
@@ -39,7 +39,7 @@ test('valid preset development', t => {
   const config = api.config.toConfig();
 
   // Common
-  t.deepEqual(config.resolve.extensions.slice(0, 2), newExtensions);
+  t.deepEqual(config.resolve.extensions.slice(0, newExtensions.length), newExtensions);
 
   const errors = validate(config);
   t.is(errors.length, 0);
@@ -52,7 +52,7 @@ test('valid preset test', t => {
   const config = api.config.toConfig();
 
   // Common
-  t.deepEqual(config.resolve.extensions.slice(0, 2), newExtensions);
+  t.deepEqual(config.resolve.extensions.slice(0, newExtensions.length), newExtensions);
 
   const errors = validate(config);
   t.is(errors.length, 0);


### PR DESCRIPTION
As described in the `react-native-web` [doc](https://github.com/necolas/react-native-web/blob/master/packages/website/guides/getting-started.md#multi-platform-applications) there is the new file extension `.web.js{x}` needed for significant platform differences.
This PR adds those extensions.
Discussion see [here](https://github.com/neutrinojs/neutrino/issues/1056).

Fixes #1056.