### PR TITLE
web/library: Remove worker-loader

### DIFF
--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -428,7 +428,6 @@ The following is a list of rules and their identifiers which can be overridden:
 | Name | Description | Environments and Commands |
 | --- | --- | --- |
 | `compile` | Compiles JS files from the `src` directory using Babel. Contains a single loader named `babel` | all |
-| `worker` | Allows importing Web Workers automatically with `.worker.*` extensions. Contains a single loader named `worker`. | all |
 
 ### Plugins
 

--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -85,14 +85,6 @@ module.exports = (neutrino, opts = {}) => {
           .set('__dirname', false);
       })
       .end()
-    .module
-      .rule('worker')
-        .test(/\.worker\.js$/)
-        .use('worker')
-          .loader(require.resolve('worker-loader'))
-          .end()
-        .end()
-      .end()
     // The default output is too noisy, particularly with multiple entrypoints.
     .stats({
       children: false,

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -38,8 +38,7 @@
     "@neutrinojs/compile-loader": "9.0.0-0",
     "@neutrinojs/loader-merge": "9.0.0-0",
     "deepmerge": "^1.5.2",
-    "webpack-node-externals": "^1.7.2",
-    "worker-loader": "^2.0.0"
+    "webpack-node-externals": "^1.7.2"
   },
   "peerDependencies": {
     "neutrino": "^9.0.0-0",

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -13,7 +13,7 @@
 - Compatibility and pre-configured aliasing for React-based modules and packages
 - Extends from [@neutrinojs/web](https://neutrinojs.org/packages/web/)
   - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
-  - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
+  - webpack loaders for importing HTML, CSS, images, icons, and fonts
   - webpack Dev Server during development
   - Automatic creation of HTML pages, no templating necessary
   - Automatic stylesheet extraction; importing stylesheets into modules creates bundled external stylesheets

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -13,12 +13,11 @@ other Neutrino middleware, so you can build, test, and publish multiple React co
 - Modern Babel compilation adding JSX, object rest spread syntax, and class properties.
 - Support for React Hot Loader
 - Write JSX in .js or .jsx files
-- Support for importing web workers with `.worker.*` file extensions
 - Compiles to ES5 to support major browsers, publishing to npm, and library
   interoperability
 - Extends partially from [@neutrinojs/web](https://neutrinojs.org/packages/web/)
   - Modern Babel compilation supporting ES modules, async functions, and dynamic imports
-  - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
+  - webpack loaders for importing HTML, CSS, images, icons, and fonts
   - webpack Dev Server during development
   - Automatic stylesheet extraction; importing stylesheets into modules creates bundled external stylesheets
   - Pre-configured to support CSS Modules via `*.module.css` file extensions

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -13,7 +13,7 @@
 - Write JSX in .js or .jsx files
 - Extends from [@neutrinojs/web](https://neutrinojs.org/packages/web/)
   - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
-  - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
+  - webpack loaders for importing HTML, CSS, images, icons, and fonts
   - webpack Dev Server during development
   - Automatic creation of HTML pages, no templating necessary
   - Automatic stylesheet extraction; importing stylesheets into modules creates bundled external stylesheets

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -9,7 +9,7 @@
 - Modern Babel compilation.
 - Extends from [@neutrinojs/web](https://neutrinojs.org/packages/web/)
   - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
-  - webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
+  - webpack loaders for importing HTML, CSS, images, icons, and fonts
   - webpack Dev Server during development
   - Automatic creation of HTML pages, no templating necessary
   - Automatic stylesheet extraction; importing stylesheets into modules creates bundled external stylesheets

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -9,7 +9,7 @@
 
 - Zero upfront configuration necessary to start developing and building a web app
 - Modern Babel compilation supporting ES modules, last 2 major browser versions, async functions, and dynamic imports
-- webpack loaders for importing HTML, CSS, images, icons, fonts, and web workers
+- webpack loaders for importing HTML, CSS, images, icons, and fonts
 - webpack Dev Server during development
 - Automatic creation of HTML pages, no templating necessary
 - Automatic stylesheet extraction; importing stylesheets into modules creates bundled external stylesheets
@@ -455,7 +455,6 @@ The following is a list of rules and their identifiers which can be overridden:
 | `style-modules` | Allows importing CSS Modules styles from modules. In production contains two loaders named `extract` and `css` which use `MiniCssExtractPlugin.loader` and `css-loader`, respectively. In development the `extract` loader is replaced by `style`, which uses `style-loader`. From `@neutrinojs/style-loader`. | all |
 | `image` | Allows importing ICO, JPEG, PNG, GIF, SVG and WEBP files from modules. Contains a single loader named `url`. From `@neutrinojs/image-loader`. | all |
 | `font` | Allows importing EOT, TTF, WOFF and WOFF2 font files from modules. Contains a single loader named `file`. From `@neutrinojs/font-loader`. | all |
-| `worker` | Allows importing Web Workers automatically with `.worker.*` extensions. Contains a single loader named `worker`. | all |
 
 ### Plugins
 

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -183,14 +183,6 @@ module.exports = (neutrino, opts = {}) => {
       .set('fs', 'empty')
       .set('tls', 'empty')
       .end()
-    .module
-      .rule('worker')
-        .test(neutrino.regexFromExtensions(neutrino.options.extensions.map(ext => `worker.${ext}`)))
-        .use('worker')
-          .loader(require.resolve('worker-loader'))
-          .end()
-        .end()
-      .end()
     // The default output is too noisy, particularly with multiple entrypoints.
     .stats({
       children: false,

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -37,8 +37,7 @@
     "@neutrinojs/style-loader": "9.0.0-0",
     "deepmerge": "^1.5.2",
     "html-webpack-include-sibling-chunks-plugin": "^0.1.4",
-    "webpack-manifest-plugin": "^2.0.2",
-    "worker-loader": "^2.0.0"
+    "webpack-manifest-plugin": "^2.0.2"
   },
   "peerDependencies": {
     "neutrino": "^9.0.0-0",


### PR DESCRIPTION
Since the top-level presets aim to cover the 80% case, and web workers are still less common. If after Neutrino 9's release there ends up being demand for them, we'd be better off having a separate opt-in preset (similar to `@neutrinojs/pwa`).