### PR TITLE
Reduce verbosity of webpack compile output

### DIFF
--- a/packages/dev-server/index.js
+++ b/packages/dev-server/index.js
@@ -36,17 +36,11 @@ module.exports = (neutrino, opts = {}) => {
       headers: {
         host: publicHost
       },
+      // Only display compile duration and errors/warnings, to reduce noise when rebuilding.
       stats: {
-        assets: false,
-        children: false,
-        chunks: false,
-        colors: true,
+        all: false,
         errors: true,
-        hash: false,
-        modules: false,
-        publicPath: false,
-        timings: false,
-        version: false,
+        timings: true,
         warnings: true
       }
     },

--- a/packages/karma/index.js
+++ b/packages/karma/index.js
@@ -52,8 +52,14 @@ module.exports = neutrino => {
         [sources]: ['webpack']
       },
       webpackMiddleware: {
-        // Using minimal rather than 'errors-only' so that warnings are still shown.
-        stats: 'minimal'
+        // Only display webpack compile duration and errors/warnings, since
+        // the focus should be on the output from the tests/karma instead.
+        stats: {
+          all: false,
+          errors: true,
+          timings: true,
+          warnings: true
+        }
       },
       webpack: merge(
         omit(neutrino.config.toConfig(), ['plugins', 'entry']),

--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -93,13 +93,11 @@ module.exports = (neutrino, opts = {}) => {
           .end()
         .end()
       .end()
-    .when(neutrino.options.debug, (config) => {
-      config.merge({
-        stats: {
-          maxModules: Infinity,
-          optimizationBailout: true
-        }
-      });
+    // The default output is too noisy, particularly with multiple entrypoints.
+    .stats({
+      children: false,
+      entrypoints: false,
+      modules: false
     })
     .when(neutrino.config.module.rules.has('lint'), () => {
       if (options.target === 'node') {

--- a/packages/library/test/library_test.js
+++ b/packages/library/test/library_test.js
@@ -40,6 +40,11 @@ test('valid preset production', t => {
   t.deepEqual(config.resolve.extensions, expectedExtensions);
   t.is(config.optimization, undefined);
   t.is(config.devServer, undefined);
+  t.deepEqual(config.stats, {
+    children: false,
+    entrypoints: false,
+    modules: false
+  });
 
   // NODE_ENV/command specific
   t.is(config.devtool, 'source-map');
@@ -61,6 +66,11 @@ test('valid preset development', t => {
   t.deepEqual(config.resolve.extensions, expectedExtensions);
   t.is(config.optimization, undefined);
   t.is(config.devServer, undefined);
+  t.deepEqual(config.stats, {
+    children: false,
+    entrypoints: false,
+    modules: false
+  });
 
   // NODE_ENV/command specific
   t.is(config.devtool, 'source-map');

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -57,9 +57,6 @@ module.exports = (neutrino, opts = {}) => {
 
   neutrino.config
     .when(sourceMap, () => neutrino.use(banner))
-    .performance
-      .hints(false)
-      .end()
     .target('node')
     .node
       .set('__filename', false)
@@ -79,13 +76,11 @@ module.exports = (neutrino, opts = {}) => {
         .merge(neutrino.options.extensions.concat('json').map(ext => `.${ext}`))
         .end()
       .end()
-    .when(neutrino.options.debug, (config) => {
-      config.merge({
-        stats: {
-          maxModules: Infinity,
-          optimizationBailout: true
-        }
-      });
+    // The default output is too noisy, particularly with multiple entrypoints.
+    .stats({
+      children: false,
+      entrypoints: false,
+      modules: false
     })
     .when(process.env.NODE_ENV === 'development', (config) => {
       const mainKeys = Object.keys(neutrino.options.mains);

--- a/packages/node/test/node_test.js
+++ b/packages/node/test/node_test.js
@@ -39,6 +39,11 @@ test('valid preset production', t => {
   t.deepEqual(config.resolve.extensions, expectedExtensions);
   t.is(config.optimization, undefined);
   t.is(config.devServer, undefined);
+  t.deepEqual(config.stats, {
+    children: false,
+    entrypoints: false,
+    modules: false
+  });
 
   // NODE_ENV/command specific
   t.is(config.devtool, 'source-map');
@@ -58,6 +63,11 @@ test('valid preset development', t => {
   t.deepEqual(config.resolve.extensions, expectedExtensions);
   t.is(config.optimization, undefined);
   t.is(config.devServer, undefined);
+  t.deepEqual(config.stats, {
+    children: false,
+    entrypoints: false,
+    modules: false
+  });
 
   // NODE_ENV/command specific
   t.is(config.devtool, 'inline-sourcemap');

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -191,6 +191,12 @@ module.exports = (neutrino, opts = {}) => {
           .end()
         .end()
       .end()
+    // The default output is too noisy, particularly with multiple entrypoints.
+    .stats({
+      children: false,
+      entrypoints: false,
+      modules: false
+    })
     .when(neutrino.config.module.rules.has('lint'), () => {
       neutrino.use(loaderMerge('lint', 'eslint'), {
         envs: ['browser', 'commonjs']

--- a/packages/web/test/web_test.js
+++ b/packages/web/test/web_test.js
@@ -33,6 +33,11 @@ test('valid preset production', t => {
   t.deepEqual(config.resolve.extensions, expectedExtensions);
   t.is(config.optimization.runtimeChunk, 'single');
   t.is(config.optimization.splitChunks.chunks, 'all');
+  t.deepEqual(config.stats, {
+    children: false,
+    entrypoints: false,
+    modules: false
+  });
 
   // NODE_ENV/command specific
   t.true(config.optimization.minimize);
@@ -55,6 +60,11 @@ test('valid preset development', t => {
   t.deepEqual(config.resolve.extensions, expectedExtensions);
   t.is(config.optimization.runtimeChunk, 'single');
   t.is(config.optimization.splitChunks.chunks, 'all');
+  t.deepEqual(config.stats, {
+    children: false,
+    entrypoints: false,
+    modules: false
+  });
 
   // NODE_ENV/command specific
   t.false(config.optimization.minimize);
@@ -65,6 +75,12 @@ test('valid preset development', t => {
   t.is(config.devServer.port, 5000);
   t.is(config.devServer.public, 'localhost:5000');
   t.is(config.devServer.publicPath, '/');
+  t.deepEqual(config.devServer.stats, {
+    all: false,
+    errors: true,
+    timings: true,
+    warnings: true
+  });
 
   const errors = validate(config);
   t.is(errors.length, 0);
@@ -81,6 +97,11 @@ test('valid preset test', t => {
   t.deepEqual(config.resolve.extensions, expectedExtensions);
   t.is(config.optimization.runtimeChunk, 'single');
   t.is(config.optimization.splitChunks.chunks, 'all');
+  t.deepEqual(config.stats, {
+    children: false,
+    entrypoints: false,
+    modules: false
+  });
 
   // NODE_ENV/command specific
   t.false(config.optimization.minimize);


### PR DESCRIPTION
This adjusts the console output to be less verbose, for parity with how it was prior to the switch to native CLIs in #852.

In some cases the output has been made to be even more concise than in Neutrino 8, since it's now possible for users to adjust the output via CLI flags, therefore less important to satisfy all use-cases out of the box. For that reason the `debug` handling has also been removed.

The output when using webpack-dev-server now includes the duration, which makes it much easier to compare incremental build times.

The `performance.hints(false)` of `@neutrinojs/node` has been removed since it's redundant as of webpack 4.2.0:
https://github.com/webpack/webpack/commit/c65fb74a2606631a1d681ab1af0fd53c0d922893

Fixes #897.