### PR TITLE
Docs: Correct the order of loaders in postcss-loader example

### DIFF
--- a/packages/style-loader/README.md
+++ b/packages/style-loader/README.md
@@ -146,18 +146,20 @@ module.exports = {
     test: /\.(css|sass|scss)$/,
     moduleTest: /\.module\.(css|sass|scss)$/,
     loaders: [
-      // Define loaders as objects
+      // Define loaders as objects. Note: loaders must be specified in reverse order.
+      // ie: for the loaders below the actual execution order would be:
+      // input file -> sass-loader -> postcss-loader -> css-loader -> style-loader/mini-css-extract-plugin
+      {
+        loader: 'postcss-loader',
+        options: {
+          plugins: [require('autoprefixer')]
+        }
+      },
       {
         loader: 'sass-loader',
         useId: 'sass',
         options: {
           includePaths: ['absolute/path/a', 'absolute/path/b']
-        }
-      },
-      {
-        loader: 'postcss-loader',
-        options: {
-          plugins: [require('autoprefixer')]
         }
       }
     ]


### PR DESCRIPTION
Since `postcss-loader` must be applied *after* `sass-loader` (and before `css-loader`) according to:
https://github.com/postcss/postcss-loader#config-cascade

...whereas previously it was being applied *before* `sass-loader`, since webpack applies loaders in the order of "last to first".

See:
https://github.com/neutrinojs/neutrino/issues/1066#issuecomment-418682483

After merging this, I'll cherrypick to the `release/v8` branch.