### PR TITLE
Throw errors that arise from spawning processes in create-project

### DIFF
--- a/packages/create-project/commands/init/index.js
+++ b/packages/create-project/commands/init/index.js
@@ -36,7 +36,13 @@ module.exports = class Project extends Generator {
       const command = [args[0], ...args[1]].join(' ');
 
       removeSync(this.options.directory);
-      this.log.error(result.error || new Error(`The command "${command}" exited unsuccessfully.`));
+      this.log.error(
+        result.error ||
+        new Error(
+          `The command "${command}" exited unsuccessfully. Try again with the --debug flag` +
+          'for more detailed information about the failure.'
+        )
+      );
       process.exit(result.status || 1);
     }
 

--- a/packages/create-project/commands/init/index.js
+++ b/packages/create-project/commands/init/index.js
@@ -114,10 +114,14 @@ module.exports = class Project extends Generator {
 
     ensureDirSync(this.options.directory);
 
-    this.spawnCommandSync(installer, ['init', '--yes'], {
+    const { error } = this.spawnCommandSync(installer, ['init', '--yes'], {
       cwd: this.options.directory,
       stdio: this.options.stdio
     });
+
+    if (error) {
+      throw error;
+    }
 
     const jsonPath = join(this.options.directory, 'package.json');
     const json = readJsonSync(jsonPath);
@@ -174,7 +178,8 @@ module.exports = class Project extends Generator {
 
     if (dependencies.length) {
       this.log(`${chalk.green('⏳  Installing dependencies:')} ${chalk.yellow(dependencies.join(', '))}`);
-      this.spawnCommandSync(
+
+      const { error } = this.spawnCommandSync(
         packageManager,
         [
           install,
@@ -191,11 +196,16 @@ module.exports = class Project extends Generator {
           env: process.env
         }
       );
+
+      if (error) {
+        throw error;
+      }
     }
 
     if (devDependencies.length) {
       this.log(`${chalk.green('⏳  Installing devDependencies:')} ${chalk.yellow(devDependencies.join(', '))}`);
-      this.spawnCommandSync(
+
+      const { error } = this.spawnCommandSync(
         packageManager,
         [
           install,
@@ -213,11 +223,16 @@ module.exports = class Project extends Generator {
           env: process.env
         }
       );
+
+      if (error) {
+        throw error;
+      }
     }
 
     if (this.data.linter) {
       this.log(`${chalk.green('⏳  Performing one-time lint')}`);
-      this.spawnCommandSync(packageManager,
+
+      const { error } = this.spawnCommandSync(packageManager,
         isYarn
           ? ['lint', '--fix']
           : ['run', 'lint', '--fix'],
@@ -228,6 +243,10 @@ module.exports = class Project extends Generator {
           env: process.env,
           cwd: this.options.directory
         });
+
+      if (error) {
+        throw error;
+      }
     }
   }
 

--- a/packages/create-project/test/cli_test.js
+++ b/packages/create-project/test/cli_test.js
@@ -34,6 +34,8 @@ const tests = {
   }
 };
 const project = async ({ testName, ...prompts }) => {
+  // Replace special characters in the test name to ensure that it can be
+  // used as a valid directory name.
   const directory = `${join(tmpdir(), testName.replace(/[/+ @]/g, '_'))
      }_${Math.random().toString(36).substr(2)}`;
 

--- a/packages/create-project/test/cli_test.js
+++ b/packages/create-project/test/cli_test.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 import assert from 'yeoman-assert';
 import helpers from 'yeoman-test';
+import { tmpdir } from 'os';
 import { join } from 'path';
 import { spawn } from 'child_process';
 import { packages } from '../commands/init/matrix';
@@ -32,17 +33,21 @@ const tests = {
     linter: packages.AIRBNB_BASE
   }
 };
-const project = (prompts) => helpers
-  .run(require.resolve(join(__dirname, '../commands/init')))
-  .inTmpDir(function setOptions(dir) {
-    this.withOptions({
-      directory: dir,
-      name: 'testable',
+const project = async ({ testName, ...prompts }) => {
+  const directory = `${join(tmpdir(), testName.replace(/[/+ @]/g, '_'))
+     }_${Math.random().toString(36).substr(2)}`;
+
+  await helpers
+    .run(require.resolve(join(__dirname, '../commands/init')))
+    .withOptions({
+      directory,
+      name: testName,
       registry: REGISTRY
-    });
-  })
-  .withPrompts(prompts)
-  .toPromise();
+    })
+    .withPrompts(prompts);
+
+  return directory;
+};
 const spawnP = (cmd, args, options) => new Promise((resolve, reject) => {
   const child = spawn(cmd, args, options);
   let output = '';
@@ -92,6 +97,7 @@ Object.keys(tests).forEach(projectName => {
 
   test.serial(testName, async t => {
     const dir = await project({
+      testName,
       projectType,
       linter,
       project: projectName,


### PR DESCRIPTION
Fixes #895.

This PR doesn't attempt to know why an error occurs, but it should at least make them visible should an operation fail during create-project. According to the yeoman docs, `spawnCommandSync` returns an instance of cross-spawn `sync`, which wraps Node's child_process `spawnSync`.

http://yeoman.io/generator/actions_spawn-command.js.html
https://www.npmjs.com/package/cross-spawn
https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options

The `error` property of the result object is either `null` or an `Error` instance, so we just throw it if it exists.