### PR TITLE
Support options for jest and karma presets in v9

### DIFF
--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -27,6 +27,7 @@
     "@neutrinojs/compile-loader": "9.0.0-0",
     "@neutrinojs/loader-merge": "9.0.0-0",
     "babel-plugin-jest-hoist": "^23.0.0",
+    "deepmerge": "^1.5.2",
     "eslint-plugin-jest": "^21.21.0",
     "lodash.omit": "^4.5.0"
   },

--- a/packages/jest/src/index.js
+++ b/packages/jest/src/index.js
@@ -1,10 +1,11 @@
 const loaderMerge = require('@neutrinojs/loader-merge');
-const { merge } = require('@neutrinojs/compile-loader');
+const compileLoader = require('@neutrinojs/compile-loader');
+const merge = require('deepmerge');
 const omit = require('lodash.omit');
 const { basename, isAbsolute, join, relative } = require('path');
 const { media, style } = require('neutrino/extensions');
 
-module.exports = neutrino => {
+module.exports = (neutrino, options = {}) => {
   neutrino.config.when(neutrino.config.module.rules.has('lint'), () => {
     neutrino.use(loaderMerge('lint', 'eslint'), {
       plugins: ['jest'],
@@ -25,7 +26,7 @@ module.exports = neutrino => {
       neutrino.config.module
         .rule('compile')
         .use('babel')
-        .tap(options => merge(options, {
+        .tap(options => compileLoader.merge(options, {
           plugins: [
             // Once babel-preset-jest has better Babel 7 support we should
             // switch back to it (or even use babel-jest, which will allow
@@ -43,7 +44,7 @@ module.exports = neutrino => {
     }
 
     const babelOptions = usingBabel
-      ? merge(
+      ? compileLoader.merge(
         omit(
           neutrino.config.module.rule('compile').use('babel').get('options'),
           ['cacheDirectory']
@@ -76,7 +77,7 @@ module.exports = neutrino => {
     const modulesConfig = neutrino.config.resolve.modules.values();
     const aliases = neutrino.config.resolve.alias.entries() || {};
 
-    return {
+    return merge({
       rootDir: root,
       moduleDirectories: modulesConfig.length ? modulesConfig : ['node_modules'],
       moduleFileExtensions: neutrino.config.resolve.extensions
@@ -112,6 +113,6 @@ module.exports = neutrino => {
       globals: {
         BABEL_OPTIONS: babelOptions
       }
-    };
+    }, options);
   });
 };

--- a/packages/jest/test/jest_test.js
+++ b/packages/jest/test/jest_test.js
@@ -15,8 +15,9 @@ test('loads middleware', t => {
 });
 
 test('uses middleware', t => {
+  const api = new Neutrino();
+
   t.notThrows(() => {
-    const api = new Neutrino();
     api.use(mw());
   });
 });
@@ -65,4 +66,10 @@ test('exposes jest method', t => {
 
 test('exposes jest config from method', t => {
   t.is(typeof neutrino(mw()).jest(), 'object');
+});
+
+test('uses middleware with options', t => {
+  const config = neutrino([mw(), { testEnvironment: 'node' }]).jest();
+
+  t.is(config.testEnvironment, 'node');
 });

--- a/packages/karma/index.js
+++ b/packages/karma/index.js
@@ -4,7 +4,7 @@ const merge = require('deepmerge');
 const omit = require('lodash.omit');
 const { join } = require('path');
 
-module.exports = neutrino => {
+module.exports = (neutrino, options = {}) => {
   if (neutrino.config.module.rules.has('lint')) {
     neutrino.use(loaderMerge('lint', 'eslint'), {
       envs: ['mocha']
@@ -24,7 +24,7 @@ module.exports = neutrino => {
     const tests = join(neutrino.options.tests, '**/*_test.js');
     const sources = join(neutrino.options.source, '**/*.js*');
 
-    config.set({
+    config.set(merge({
       basePath: neutrino.options.root,
       browsers: [process.env.CI ? 'ChromeCI' : 'ChromeHeadless'],
       customLaunchers: {
@@ -80,7 +80,7 @@ module.exports = neutrino => {
           { type: 'lcov', subdir: 'report-lcov' }
         ]
       }
-    });
+    }, options));
 
     return config;
   });

--- a/packages/karma/test/karma_test.js
+++ b/packages/karma/test/karma_test.js
@@ -74,3 +74,22 @@ test('exposes karma config from method', t => {
 
   t.is(config, fakeKarma);
 });
+
+test('uses middleware with options', t => {
+  // Karma's config handler returns a function.
+  // Force evaluation by calling it.
+  const fakeKarma = new Map();
+  const config = neutrino([mw(), {
+    webpackMiddleware: {
+      stats: {
+        errors: false
+      }
+    }
+  }]).karma()(fakeKarma);
+
+  // Since we are faking out the Karma API with a Map, we need to get the
+  // object back out of the map and check that the merge happened correctly.
+  const [options] = [...config][0];
+
+  t.is(options.webpackMiddleware.stats.errors, false);
+});


### PR DESCRIPTION
Fixes #907.

This patch re-introduces the ability to pass options to the jest and karma presets. It *does not* support options for mocha since mocha has no configuration file to be able to pass options to.