### PR TITLE
Test create-project buildable in development mode

### DIFF
--- a/packages/create-project/test/cli_test.js
+++ b/packages/create-project/test/cli_test.js
@@ -51,7 +51,7 @@ const spawnP = (cmd, args, options) => new Promise((resolve, reject) => {
   child.stderr.on('data', data => { output += data.toString(); });
   child.on('close', code => (code === 0 ? resolve(code) : reject(output)));
 });
-const buildable = async (t, dir, args) => {
+const buildable = async (t, dir, args = []) => {
   try {
     await spawnP('yarn', ['build', ...args], { cwd: dir, stdio: 'pipe' });
     t.pass();
@@ -59,7 +59,7 @@ const buildable = async (t, dir, args) => {
     t.fail(`Failed to build project:\n\n${output}`);
   }
 };
-const testable = async (t, dir, args) => {
+const testable = async (t, dir, args = []) => {
   try {
     await spawnP('yarn', ['test', ...args], { cwd: dir, stdio: 'pipe' });
     t.pass();
@@ -67,7 +67,7 @@ const testable = async (t, dir, args) => {
     t.fail(`Failed to test project:\n\n${output}`);
   }
 };
-const lintable = async (t, dir, args) => {
+const lintable = async (t, dir, args = []) => {
   try {
     await spawnP('yarn', ['lint', ...args], { cwd: dir, stdio: 'pipe' });
     t.pass();

--- a/packages/create-project/test/cli_test.js
+++ b/packages/create-project/test/cli_test.js
@@ -51,25 +51,25 @@ const spawnP = (cmd, args, options) => new Promise((resolve, reject) => {
   child.stderr.on('data', data => { output += data.toString(); });
   child.on('close', code => (code === 0 ? resolve(code) : reject(output)));
 });
-const buildable = async (t, dir) => {
+const buildable = async (t, dir, args) => {
   try {
-    await spawnP('yarn', ['build'], { cwd: dir, stdio: 'pipe' });
+    await spawnP('yarn', ['build', ...args], { cwd: dir, stdio: 'pipe' });
     t.pass();
   } catch (output) {
     t.fail(`Failed to build project:\n\n${output}`);
   }
 };
-const testable = async (t, dir) => {
+const testable = async (t, dir, args) => {
   try {
-    await spawnP('yarn', ['test'], { cwd: dir, stdio: 'pipe' });
+    await spawnP('yarn', ['test', ...args], { cwd: dir, stdio: 'pipe' });
     t.pass();
   } catch (output) {
     t.fail(`Failed to test project:\n\n${output}`);
   }
 };
-const lintable = async (t, dir) => {
+const lintable = async (t, dir, args) => {
   try {
-    await spawnP('yarn', ['lint'], { cwd: dir, stdio: 'pipe' });
+    await spawnP('yarn', ['lint', ...args], { cwd: dir, stdio: 'pipe' });
     t.pass();
   } catch (output) {
     t.fail(`Failed to lint project:\n\n${output}`);
@@ -97,15 +97,22 @@ Object.keys(tests).forEach(projectName => {
       project: projectName,
       testRunner: tester || false
     });
+    const pkgPath = join(dir, 'package.json');
 
     t.truthy(dir);
-    assert.file(join(dir, 'package.json'));
+    assert.file(pkgPath);
     assert.file(join(dir, '.neutrinorc.js'));
     assert.file(join(dir, 'webpack.config.js'));
     assert.file(join(dir, '.eslintrc.js'));
 
     await lintable(t, dir);
     await buildable(t, dir);
+
+    const pkg = require(pkgPath); // eslint-disable-line import/no-dynamic-require
+
+    if ('start' in pkg.scripts) {
+      await buildable(t, dir, ['--', '--mode', 'development']);
+    }
 
     if (tester) {
       if (tester === packages.JEST) {

--- a/packages/create-project/test/cli_test.js
+++ b/packages/create-project/test/cli_test.js
@@ -110,6 +110,10 @@ Object.keys(tests).forEach(projectName => {
 
     const pkg = require(pkgPath); // eslint-disable-line import/no-dynamic-require
 
+    // Building in development mode to emulating running webpack-dev-server
+    // or webpack --watch without actually spawning the process and waiting.
+    // TODO: Find a way in the future to actually test that the spawned watchers
+    // produce the expected result.
     if ('start' in pkg.scripts) {
       await buildable(t, dir, ['--', '--mode', 'development']);
     }


### PR DESCRIPTION
Fixes #886.

This patch is a stop-gap for testing create-project output works in development mode by only overriding the build command, not start.