### PR TITLE
Add webpack-cli to peerDependencies

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -42,6 +42,7 @@
   },
   "peerDependencies": {
     "neutrino": "^9.0.0-0",
-    "webpack": "^4.0.0"
+    "webpack": "^4.0.0",
+    "webpack-cli": "^3.0.0"
   }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -36,6 +36,7 @@
   },
   "peerDependencies": {
     "neutrino": "^9.0.0-0",
-    "webpack": "^4.0.0"
+    "webpack": "^4.0.0",
+    "webpack-cli": "^3.0.0"
   }
 }

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -37,6 +37,7 @@
   },
   "peerDependencies": {
     "neutrino": "^9.0.0-0",
-    "webpack": "^4.0.0"
+    "webpack": "^4.0.0",
+    "webpack-cli": "^3.0.0"
   }
 }

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -27,6 +27,7 @@
   },
   "peerDependencies": {
     "neutrino": "^9.0.0-0",
-    "webpack": "^4.0.0"
+    "webpack": "^4.0.0",
+    "webpack-cli": "^3.0.0"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,6 +40,7 @@
   },
   "peerDependencies": {
     "neutrino": "^9.0.0-0",
-    "webpack": "^4.0.0"
+    "webpack": "^4.0.0",
+    "webpack-cli": "^3.0.0"
   }
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -37,6 +37,7 @@
   },
   "peerDependencies": {
     "neutrino": "^9.0.0-0",
-    "webpack": "^4.0.0"
+    "webpack": "^4.0.0",
+    "webpack-cli": "^3.0.0"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -41,6 +41,7 @@
   },
   "peerDependencies": {
     "neutrino": "^9.0.0-0",
-    "webpack": "^4.0.0"
+    "webpack": "^4.0.0",
+    "webpack-cli": "^3.0.0"
   }
 }


### PR DESCRIPTION
Since `webpack-command` is no longer actively maintained, so users should just be using `webpack-cli`.

Fixes #1086.