### PR TITLE
eslint: Remove unused dependency on 'debug'

### DIFF
--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "babel-eslint": "^9.0.0",
-    "debug": "^3.1.0",
     "deepmerge": "^1.5.2",
     "eslint-loader": "^2.1.0",
     "eslint-plugin-babel": "^5.1.0",


### PR DESCRIPTION
It stopped being used as of #852.

Closes #1096.