### PR TITLE
Make removal of the 'polyfills' option more obvious

### DIFF
--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -10,6 +10,10 @@ module.exports = (neutrino, opts = {}) => {
     throw new Error('Missing required preset option "name". You must specify a library name when using this preset.');
   }
 
+  if ('polyfills' in opts) {
+    throw new Error('The polyfills option has been removed, since polyfills are no longer included by default.');
+  }
+
   const options = merge({
     target: 'web',
     libraryTarget: 'umd',

--- a/packages/library/test/library_test.js
+++ b/packages/library/test/library_test.js
@@ -28,6 +28,13 @@ test('throws when missing library name', t => {
   t.true(err.message.includes('You must specify a library name'));
 });
 
+test('throws when polyfills defined', async t => {
+  const api = new Neutrino();
+
+  const err = t.throws(() => api.use(mw(), { name: 'alpha', polyfills: {} }));
+  t.true(err.message.includes('The polyfills option has been removed'));
+});
+
 test('valid preset production', t => {
   process.env.NODE_ENV = 'production';
   const api = new Neutrino();

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -20,6 +20,10 @@ const getOutputForEntry = entry => basename(
 );
 
 module.exports = (neutrino, opts = {}) => {
+  if ('polyfills' in opts) {
+    throw new Error('The polyfills option has been removed, since polyfills are no longer included by default.');
+  }
+
   const pkg = neutrino.options.packageJson;
   const sourceMap = (pkg && pkg.dependencies && pkg.dependencies['source-map-support']) ||
     pkg && pkg.devDependencies && pkg.devDependencies['source-map-support'] ||

--- a/packages/node/test/node_test.js
+++ b/packages/node/test/node_test.js
@@ -75,3 +75,10 @@ test('valid preset development', t => {
   const errors = validate(config);
   t.is(errors.length, 0);
 });
+
+test('throws when polyfills defined', async t => {
+  const api = new Neutrino();
+
+  const err = t.throws(() => api.use(mw(), { polyfills: {} }));
+  t.true(err.message.includes('The polyfills option has been removed'));
+});

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -58,6 +58,10 @@ module.exports = (neutrino, opts = {}) => {
     throw new Error('The minify.style option has been removed. To enable style minification use the @neutrinojs/style-minify preset.');
   }
 
+  if ('polyfills' in options) {
+    throw new Error('The polyfills option has been removed, since polyfills are no longer included by default.');
+  }
+
   if (typeof options.devtool === 'string' || typeof options.devtool === 'boolean') {
     options.devtool = {
       development: options.devtool,

--- a/packages/web/test/web_test.js
+++ b/packages/web/test/web_test.js
@@ -260,3 +260,10 @@ test('throws when minify.style defined', async t => {
   const err = t.throws(() => api.use(mw(), { minify: { style: false } }));
   t.true(err.message.includes('The minify.style option has been removed'));
 });
+
+test('throws when polyfills defined', async t => {
+  const api = new Neutrino();
+
+  const err = t.throws(() => api.use(mw(), { polyfills: {} }));
+  t.true(err.message.includes('The polyfills option has been removed'));
+});


### PR DESCRIPTION
Support for the preset option `polyfills.babel` was removed in #315 (Neutrino 7), leaving just `polyfills.async` which was removed in #790.