### PR TITLE
[v8.x] Stop testing against Preact since the tests are failing

### DIFF
--- a/packages/create-project/test/cli_test.js
+++ b/packages/create-project/test/cli_test.js
@@ -59,11 +59,6 @@ const matrix = {
     [packages.AIRBNB, packages.STANDARDJS],
     tests
   ],
-  preact: [
-    [packages.PREACT],
-    [packages.AIRBNB, packages.STANDARDJS],
-    tests
-  ],
   node: [
     [packages.NODE],
     [packages.AIRBNB_BASE, packages.STANDARDJS],


### PR DESCRIPTION
Due to a breaking change being made in the Preact packaging in a minor version. For at least `v8/release`, Preact has now lost the right to sit at the well-tested grown-ups table.

Fixes #1078.