### PR TITLE
Docs: Remove leftover references to 'neutrino build'

### DIFF
--- a/packages/airbnb-base/README.md
+++ b/packages/airbnb-base/README.md
@@ -109,9 +109,9 @@ ERROR in ./src/index.js
 
 ## Building
 
-`@neutrinojs/airbnb-base` will cause errors to **fail your build** when creating a bundle via `neutrino build`. If
-you want to ease introduction of this linting preset to your project, consider only adding it to your `use` list
-during development until all linting errors have been resolved.
+`@neutrinojs/airbnb-base` will cause errors to **fail your build** when `NODE_ENV` is not `'development'`.
+If you want to ease introduction of this linting preset to your project, consider only adding it to
+your `use` list during development until all linting errors have been resolved.
 
 ```bash
 ❯ yarn build

--- a/packages/airbnb/README.md
+++ b/packages/airbnb/README.md
@@ -106,9 +106,9 @@ ERROR in ./src/index.js
 
 ## Building
 
-`@neutrinojs/airbnb` will cause errors to **fail your build** when creating a bundle via `neutrino build`. If
-you want to ease introduction of this linting preset to your project, consider only adding it to your `use` list
-during development until all linting errors have been resolved.
+`@neutrinojs/airbnb` will cause errors to **fail your build** when `NODE_ENV` is not `'development'`.
+If you want to ease introduction of this linting preset to your project, consider only adding it to
+your `use` list during development until all linting errors have been resolved.
 
 ```bash
 ❯ yarn build

--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -169,8 +169,8 @@ You can now build your library!
 
 ## Building
 
-`@neutrinojs/library` builds assets to the `build` directory by default when running `neutrino build`. Using the
-quick start example above as a reference:
+`@neutrinojs/library` builds assets to the `build` directory by default when running `yarn build`.
+Using the quick start example above as a reference:
 
 ```bash
 ❯ yarn build
@@ -342,7 +342,7 @@ of `redux-example`._
   "version": "1.0.0",
   "main": "build/reduxExample.js",
   "scripts": {
-    "build": "neutrino build"
+    "build": "webpack --mode production"
   },
   "dependencies": {
     "mitt": "*",

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -173,8 +173,8 @@ hi!
 
 ## Building
 
-`@neutrinojs/node` builds assets to the `build` directory by default when running `neutrino build`. Using
-the quick start example above as a reference:
+`@neutrinojs/node` builds assets to the `build` directory by default when running `yarn build`.
+Using the quick start example above as a reference:
 
 ```bash
 ❯ yarn build

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -171,8 +171,8 @@ Start the app, then open a browser to the address in the console:
 
 ## Building
 
-`@neutrinojs/preact` builds static assets to the `build` directory by default when running `neutrino build`. Using
-the quick start example above as a reference:
+`@neutrinojs/preact` builds static assets to the `build` directory by default when running `yarn build`.
+Using the quick start example above as a reference:
 
 ```bash
 ❯ yarn build

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -191,7 +191,7 @@ Start the app, then open a browser to the address in the console to preview your
 
 ## Building
 
-`@neutrinojs/react-components` builds components to the `build` directory by default when running `neutrino build`.
+`@neutrinojs/react-components` builds components to the `build` directory by default when running `yarn build`.
 Using the quick start example above as a reference:
 
 ```bash

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -156,8 +156,8 @@ Start the app, then open a browser to the address in the console:
 
 ## Building
 
-`@neutrinojs/react` builds static assets to the `build` directory by default when running `neutrino build`. Using
-the quick start example above as a reference:
+`@neutrinojs/react` builds static assets to the `build` directory by default when running `yarn build`.
+Using the quick start example above as a reference:
 
 ```bash
 ❯ yarn build

--- a/packages/standardjs/README.md
+++ b/packages/standardjs/README.md
@@ -106,9 +106,9 @@ ERROR in ./src/index.js
 
 ## Building
 
-`@neutrinojs/standardjs` will cause errors to **fail your build** when creating a bundle via `neutrino build`. If
-you want to ease introduction of this linting preset to your project, consider only adding it to your `use` list
-during development until all linting errors have been resolved.
+`@neutrinojs/standardjs` will cause errors to **fail your build** when `NODE_ENV` is not `'development'`.
+If you want to ease introduction of this linting preset to your project, consider only adding it to
+your `use` list during development until all linting errors have been resolved.
 
 ```bash
 ❯ yarn build

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -175,8 +175,8 @@ Start the app, then open a browser to the address in the console:
 
 ## Building
 
-`@neutrinojs/vue` builds static assets to the `build` directory by default when running `neutrino build`. Using
-the quick start example above as a reference:
+`@neutrinojs/vue` builds static assets to the `build` directory by default when running `yarn build`.
+Using the quick start example above as a reference:
 
 ```bash
 ❯ yarn build

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -151,8 +151,8 @@ Start the app, then open a browser to the address in the console:
 
 ## Building
 
-`@neutrinojs/web` builds static assets to the `build` directory by default when running `neutrino build`. Using
-the quick start example above as a reference:
+`@neutrinojs/web` builds static assets to the `build` directory by default when running `yarn build`.
+Using the quick start example above as a reference:
 
 ```bash
 ❯ yarn build


### PR DESCRIPTION
I missed these in #1108.