### PR TITLE
Move inspect to its own handler

### DIFF
--- a/packages/neutrino/bin/neutrino.js
+++ b/packages/neutrino/bin/neutrino.js
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
 const yargsParser = require('yargs-parser');
+const neutrino = require('..');
 
 const argv = yargsParser(process.argv.slice(2));
 
 if (argv.inspect) {
-  // eslint-disable-next-line global-require
-  require('../')().inspect();
+  neutrino().inspect();
+  process.exit();
 }
 
 console.error(`

--- a/packages/neutrino/handlers.js
+++ b/packages/neutrino/handlers.js
@@ -1,0 +1,23 @@
+const webpack = (neutrino) => {
+  if (neutrino.config.entryPoints.has('vendor')) {
+    throw new Error(
+      'Vendor chunks are now automatically generated. ' +
+      'Remove the manual `vendor` entrypoint.'
+    );
+  }
+
+  return neutrino.config.toConfig();
+};
+
+const inspect = (neutrino) => {
+  const stringifiedConfig = neutrino.config.toString({
+    configPrefix: 'neutrino.config',
+    verbose: true
+  });
+  console.log(stringifiedConfig);
+};
+
+module.exports = {
+  webpack,
+  inspect
+};

--- a/packages/neutrino/index.js
+++ b/packages/neutrino/index.js
@@ -1,9 +1,7 @@
 const isPlainObject = require('is-plain-object');
 const yargsParser = require('yargs-parser');
 const Neutrino = require('./Neutrino');
-const webpack = require('./webpack');
-
-const configPrefix = 'neutrino.config';
+const { webpack, inspect } = require('./handlers');
 
 module.exports = (middleware = {}) => {
   const use = isPlainObject(middleware) && !middleware.use
@@ -31,6 +29,7 @@ module.exports = (middleware = {}) => {
   }
 
   neutrino.register('webpack', webpack);
+  neutrino.register('inspect', inspect);
 
   if (use) {
     neutrino.use(use);
@@ -38,11 +37,6 @@ module.exports = (middleware = {}) => {
 
   const adapter = {
     output(name) {
-      if (name === 'inspect') {
-        console.log(neutrino.config.toString({ configPrefix }));
-        process.exit();
-      }
-
       const handler = neutrino.outputHandlers.get(name);
 
       if (!handler) {

--- a/packages/neutrino/test/package_test.js
+++ b/packages/neutrino/test/package_test.js
@@ -78,3 +78,9 @@ test('exposes webpack config from method', t => {
   const handler = neutrino(Function.prototype).webpack();
   t.is(typeof handler, 'object');
 });
+
+test('exposes inspect output handler', t => {
+  t.notThrows(() =>
+    neutrino(Function.prototype).output('inspect')
+  );
+});

--- a/packages/neutrino/webpack.js
+++ b/packages/neutrino/webpack.js
@@ -1,9 +1,0 @@
-module.exports = (neutrino) => {
-  if (neutrino.config.entryPoints.has('vendor')) {
-    throw new Error('Vendor chunks are now automatically generated. ' +
-      'Remove the manual `vendor` entrypoint.'
-    );
-  }
-
-  return neutrino.config.toConfig();
-};


### PR DESCRIPTION
And also:
* enable `toString()`'s `verbose` mode (since all of our core presets now result in clean inspect output, so there's no need to elide longer functions, especially since doing so makes it annoying when using custom functions in `.neutrinorc.js`)
* move the `process.exit()` to the neutrino bin script (since it seems wrong to exit in the handler)