### PR TITLE
html-template: Adjust minification settings to match upstream

### DIFF
--- a/packages/html-template/README.md
+++ b/packages/html-template/README.md
@@ -50,11 +50,15 @@ neutrino.use(template, {
   meta: {
     viewport: 'width=device-width, initial-scale=1'
   },
-  minify: {
-    useShortDoctype: true,
-    keepClosingSlash: true,
+  // These are copied from the new html-webpack-plugin defaults (not yet released):
+  // https://github.com/jantimon/html-webpack-plugin/pull/1048
+  minify: process.env.NODE_ENV === 'production' && {
     collapseWhitespace: true,
-    preserveLineBreaks: true
+    removeComments: true,
+    removeRedundantAttributes: true,
+    removeScriptTypeAttributes: true,
+    removeStyleLinkTypeAttributes: true,
+    useShortDoctype: true
   },
   // Override pluginId to add an additional html-template plugin instance
   pluginId: 'html'
@@ -84,11 +88,15 @@ module.exports = {
       meta: {
         viewport: 'width=device-width, initial-scale=1'
       },
-      minify: {
-        useShortDoctype: true,
-        keepClosingSlash: true,
+      // These are copied from the new html-webpack-plugin defaults (not yet released):
+      // https://github.com/jantimon/html-webpack-plugin/pull/1048
+      minify: process.env.NODE_ENV === 'production' && {
         collapseWhitespace: true,
-        preserveLineBreaks: true
+        removeComments: true,
+        removeRedundantAttributes: true,
+        removeScriptTypeAttributes: true,
+        removeStyleLinkTypeAttributes: true,
+        useShortDoctype: true
       },
       // Override pluginId to add an additional html-template plugin instance
       pluginId: 'html'

--- a/packages/html-template/index.js
+++ b/packages/html-template/index.js
@@ -1,26 +1,33 @@
 const { resolve } = require('path');
 
-const merge = require('deepmerge');
-
 module.exports = (neutrino, { pluginId = 'html', ...options } = {}) => {
   neutrino.config
     .plugin(pluginId)
     .use(require.resolve('html-webpack-plugin'), [
-      merge({
+      {
         // Use a custom template that has more features (appMountId, lang) than the default:
         // https://github.com/jantimon/html-webpack-plugin/blob/master/default_index.ejs
         template: resolve(__dirname, 'template.ejs'),
         appMountId: 'root',
         lang: 'en',
         meta: {
-          viewport: 'width=device-width, initial-scale=1'
+          viewport: 'width=device-width, initial-scale=1',
+          ...options.meta
         },
-        minify: {
-          useShortDoctype: true,
-          keepClosingSlash: true,
+        // These are copied from the new html-webpack-plugin defaults:
+        // https://github.com/jantimon/html-webpack-plugin/pull/1048
+        // Passing options.minify will overwrite these defaults entirely
+        // (intentional for parity with the html-webpack-plugin implementation).
+        // Remove this once we're using a new release containing that change.
+        minify: process.env.NODE_ENV === 'production' && {
           collapseWhitespace: true,
-          preserveLineBreaks: true
-        }
-      }, options)
+          removeComments: true,
+          removeRedundantAttributes: true,
+          removeScriptTypeAttributes: true,
+          removeStyleLinkTypeAttributes: true,
+          useShortDoctype: true
+        },
+        ...options
+      }
     ]);
 };

--- a/packages/html-template/package.json
+++ b/packages/html-template/package.json
@@ -23,7 +23,6 @@
     "yarn": ">=1.2.1"
   },
   "dependencies": {
-    "deepmerge": "^1.5.2",
     "html-webpack-plugin": "4.0.0-alpha.2"
   },
   "peerDependencies": {

--- a/packages/html-template/test/middleware_test.js
+++ b/packages/html-template/test/middleware_test.js
@@ -3,6 +3,12 @@ import Neutrino from '../../neutrino/Neutrino';
 
 const mw = () => require('..');
 const options = { title: 'Alpha Beta', appMountId: 'app' };
+const originalNodeEnv = process.env.NODE_ENV;
+
+test.afterEach(() => {
+  // Restore the original NODE_ENV after each test (which Ava defaults to 'test').
+  process.env.NODE_ENV = originalNodeEnv;
+});
 
 test('loads middleware', t => {
   t.notThrows(mw);
@@ -34,4 +40,29 @@ test('instantiates with options', t => {
   api.use(mw(), options);
 
   t.notThrows(() => api.config.toConfig());
+});
+
+test('minifies in production', t => {
+  process.env.NODE_ENV = 'production';
+  const api = new Neutrino();
+  api.use(mw());
+
+  const pluginOptions = api.config.plugin('html').get('args')[0];
+  t.deepEqual(pluginOptions.minify, {
+    collapseWhitespace: true,
+    removeComments: true,
+    removeRedundantAttributes: true,
+    removeScriptTypeAttributes: true,
+    removeStyleLinkTypeAttributes: true,
+    useShortDoctype: true
+  });
+});
+
+test('does not minify in development', t => {
+  process.env.NODE_ENV = 'development';
+  const api = new Neutrino();
+  api.use(mw());
+
+  const pluginOptions = api.config.plugin('html').get('args')[0];
+  t.false(pluginOptions.minify);
 });


### PR DESCRIPTION
The next release of `html-webpack-plugin` will enable minification by default when `mode` is production, using `minify` options that are based on those used by popular projects:
https://github.com/jantimon/html-webpack-plugin/pull/1048

Those changes haven't yet been released, so in the meantime we can emulate them via preset options, so that we can test out the new defaults sooner (ie: in the upcoming alpha/beta), rather than making the breaking change just before Neutrino 9 final.

Once a new version of `html-webpack-plugin` is released, we can stop overriding `minify` entirely.