### PR TITLE
Set ESLint CLI --format to 'codeframe'

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -79,7 +79,7 @@ commands [#852](https://github.com/neutrinojs/neutrino/pull/852):
     - `neutrino start` can typically be replaced with `webpack-dev-server --mode development`.
     - `neutrino test` can typically be replaced with the CLI of your test runner,
     e.g. `jest`, `karma start --single-run`, or `mocha --require mocha.config.js --recursive`.
-    - `neutrino lint` can typically be replaced with `eslint --cache --ext mjs,vue,jsx,js src`.
+    - `neutrino lint` can typically be replaced with `eslint --cache --format codeframe --ext mjs,jsx,js src`.
     - `neutrino --inspect` command still exists to get information about the configuration that Neutrino will use.
 - **BREAKING CHANGE** With the removal of the Neutrino CLI and its `--use` flag, the `.neutrinorc.js` file for
 setting middleware is now mandatory within a project.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -171,7 +171,7 @@ on the recommended installation instructions to lint your project.
 Example usage:
 
 ```bash
-eslint --cache --ext mjs,jsx,js src
+eslint --cache --format codeframe --ext mjs,jsx,js src
 ```
 
 Putting this into your `package.json` will allow you to lint your project using either
@@ -181,7 +181,7 @@ if desired.
 ```json
 {
   "scripts": {
-    "lint": "eslint --cache --ext mjs,jsx,js src",
+    "lint": "eslint --cache --format codeframe --ext mjs,jsx,js src",
     "lint:fix": "yarn lint --fix"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "docs:bootstrap": "pip install -r docs/requirements.txt",
     "docs:serve": "mkdocs serve",
     "link:all": "lerna exec yarn link",
-    "lint": "eslint --no-eslintrc --c ./.eslintrc.js --cache --ext js,jsx --report-unused-disable-directives \".*.js\" packages",
+    "lint": "eslint --no-eslintrc --c ./.eslintrc.js --cache --report-unused-disable-directives --format codeframe --ext js,jsx \".*.js\" packages",
     "precommit": "lint-staged",
     "release": "lerna publish",
     "release:preview": "lerna publish --skip-git --skip-npm",

--- a/packages/airbnb-base/README.md
+++ b/packages/airbnb-base/README.md
@@ -248,7 +248,7 @@ to be run via `yarn lint` or `npm run lint`:
 ```json
 {
   "scripts": {
-    "lint": "eslint --cache --ext mjs,jsx,js src"
+    "lint": "eslint --cache --format codeframe --ext mjs,jsx,js src"
   }
 }
 ```

--- a/packages/airbnb/README.md
+++ b/packages/airbnb/README.md
@@ -247,7 +247,7 @@ to be run via `yarn lint` or `npm run lint`:
 ```json
 {
   "scripts": {
-    "lint": "eslint --cache --ext mjs,jsx,js src"
+    "lint": "eslint --cache --format codeframe --ext mjs,jsx,js src"
   }
 }
 ```

--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -125,7 +125,7 @@ to be run via `yarn lint` or `npm run lint`:
 ```json
 {
   "scripts": {
-    "lint": "eslint --cache --ext mjs,jsx,js src"
+    "lint": "eslint --cache --format codeframe --ext mjs,jsx,js src"
   }
 }
 ```

--- a/packages/standardjs/README.md
+++ b/packages/standardjs/README.md
@@ -247,7 +247,7 @@ to be run via `yarn lint` or `npm run lint`:
 ```json
 {
   "scripts": {
-    "lint": "eslint --cache --ext mjs,jsx,js src"
+    "lint": "eslint --cache --format codeframe --ext mjs,jsx,js src"
   }
 }
 ```


### PR DESCRIPTION
For parity with the default `formatter` used with `eslint-loader`.

Fixes #1133.