### PR TITLE
html-template: Update to html-webpack-plugin@4.0.0-beta.1

### DIFF
--- a/packages/html-template/README.md
+++ b/packages/html-template/README.md
@@ -50,16 +50,6 @@ neutrino.use(template, {
   meta: {
     viewport: 'width=device-width, initial-scale=1'
   },
-  // These are copied from the new html-webpack-plugin defaults (not yet released):
-  // https://github.com/jantimon/html-webpack-plugin/pull/1048
-  minify: process.env.NODE_ENV === 'production' && {
-    collapseWhitespace: true,
-    removeComments: true,
-    removeRedundantAttributes: true,
-    removeScriptTypeAttributes: true,
-    removeStyleLinkTypeAttributes: true,
-    useShortDoctype: true
-  },
   // Override pluginId to add an additional html-template plugin instance
   pluginId: 'html'
 });
@@ -87,16 +77,6 @@ module.exports = {
       lang: 'en',
       meta: {
         viewport: 'width=device-width, initial-scale=1'
-      },
-      // These are copied from the new html-webpack-plugin defaults (not yet released):
-      // https://github.com/jantimon/html-webpack-plugin/pull/1048
-      minify: process.env.NODE_ENV === 'production' && {
-        collapseWhitespace: true,
-        removeComments: true,
-        removeRedundantAttributes: true,
-        removeScriptTypeAttributes: true,
-        removeStyleLinkTypeAttributes: true,
-        useShortDoctype: true
       },
       // Override pluginId to add an additional html-template plugin instance
       pluginId: 'html'

--- a/packages/html-template/index.js
+++ b/packages/html-template/index.js
@@ -14,19 +14,6 @@ module.exports = (neutrino, { pluginId = 'html', ...options } = {}) => {
           viewport: 'width=device-width, initial-scale=1',
           ...options.meta
         },
-        // These are copied from the new html-webpack-plugin defaults:
-        // https://github.com/jantimon/html-webpack-plugin/pull/1048
-        // Passing options.minify will overwrite these defaults entirely
-        // (intentional for parity with the html-webpack-plugin implementation).
-        // Remove this once we're using a new release containing that change.
-        minify: process.env.NODE_ENV === 'production' && {
-          collapseWhitespace: true,
-          removeComments: true,
-          removeRedundantAttributes: true,
-          removeScriptTypeAttributes: true,
-          removeStyleLinkTypeAttributes: true,
-          useShortDoctype: true
-        },
         ...options
       }
     ]);

--- a/packages/html-template/package.json
+++ b/packages/html-template/package.json
@@ -23,7 +23,7 @@
     "yarn": ">=1.2.1"
   },
   "dependencies": {
-    "html-webpack-plugin": "4.0.0-alpha.2"
+    "html-webpack-plugin": "4.0.0-beta.1"
   },
   "peerDependencies": {
     "neutrino": "^9.0.0-0",

--- a/packages/html-template/test/middleware_test.js
+++ b/packages/html-template/test/middleware_test.js
@@ -3,12 +3,6 @@ import Neutrino from '../../neutrino/Neutrino';
 
 const mw = () => require('..');
 const options = { title: 'Alpha Beta', appMountId: 'app' };
-const originalNodeEnv = process.env.NODE_ENV;
-
-test.afterEach(() => {
-  // Restore the original NODE_ENV after each test (which Ava defaults to 'test').
-  process.env.NODE_ENV = originalNodeEnv;
-});
 
 test('loads middleware', t => {
   t.notThrows(mw);
@@ -40,29 +34,4 @@ test('instantiates with options', t => {
   api.use(mw(), options);
 
   t.notThrows(() => api.config.toConfig());
-});
-
-test('minifies in production', t => {
-  process.env.NODE_ENV = 'production';
-  const api = new Neutrino();
-  api.use(mw());
-
-  const pluginOptions = api.config.plugin('html').get('args')[0];
-  t.deepEqual(pluginOptions.minify, {
-    collapseWhitespace: true,
-    removeComments: true,
-    removeRedundantAttributes: true,
-    removeScriptTypeAttributes: true,
-    removeStyleLinkTypeAttributes: true,
-    useShortDoctype: true
-  });
-});
-
-test('does not minify in development', t => {
-  process.env.NODE_ENV = 'development';
-  const api = new Neutrino();
-  api.use(mw());
-
-  const pluginOptions = api.config.plugin('html').get('args')[0];
-  t.false(pluginOptions.minify);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5696,10 +5696,10 @@ html-minifier@^3.2.3, html-minifier@^3.5.8:
     relateurl "0.2.x"
     uglify-js "3.4.x"
 
-html-webpack-plugin@4.0.0-alpha.2:
-  version "4.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.0.0-alpha.2.tgz#7745967e389a57a098e26963f328ebe4c19b598d"
-  integrity sha512-tyvhjVpuGqD7QYHi1l1drMQTg5i+qRxpQEGbdnYFREgOKy7aFDf/ocQ/V1fuEDlQx7jV2zMap3Hj2nE9i5eGXw==
+html-webpack-plugin@4.0.0-beta.1:
+  version "4.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.1.tgz#15b3b3634af47c79ac46c185f64e2007e0b0d14c"
+  integrity sha512-O+stuSCY5rdzX5O1l1FdH1bZqRQ7ybTi12OHzgD8u5Ogu2Usu3K7e633vxj4uOjM49ST+qCcu5rWYhqNKlpomQ==
   dependencies:
     "@types/tapable" "1.0.2"
     html-minifier "^3.2.3"


### PR DESCRIPTION
The new version includes jantimon/html-webpack-plugin#1048, which means we can remove the temporary additions made in #1121.