### PR TITLE
eslint: Pass formatter to eslint-loader as a string

### DIFF
--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -51,6 +51,7 @@ neutrino.use(eslint, {
     cwd: neutrino.options.root,
     useEslintrc: false,
     root: true,
+    // Can be the name of a built-in ESLint formatter or the module/path of an external one.
     formatter: 'codeframe',
     plugins: ['babel'],
     baseConfig: {},

--- a/packages/eslint/index.js
+++ b/packages/eslint/index.js
@@ -89,6 +89,7 @@ module.exports = (neutrino, opts = {}) => {
       cwd: neutrino.options.root,
       useEslintrc: false,
       root: true,
+      // Can be the name of a built-in ESLint formatter or the module/path of an external one.
       formatter: 'codeframe',
       // Unfortunately we can't `require.resolve('eslint-plugin-babel')` due to:
       // https://github.com/eslint/eslint/issues/6237
@@ -110,12 +111,11 @@ module.exports = (neutrino, opts = {}) => {
   const loaderOptions = options.eslint;
 
   if (typeof loaderOptions.formatter === 'string') {
-    const formatterPath = `eslint/lib/formatters/${loaderOptions.formatter}`;
-    // eslint-disable-next-line global-require, import/no-dynamic-require
-    loaderOptions.formatter = require(formatterPath);
-    // Improve the stringified output when using --inspect.
-    // eslint-disable-next-line no-underscore-dangle
-    loaderOptions.formatter.__expression = `require('${formatterPath}')`;
+    try {
+      loaderOptions.formatter = require.resolve(`eslint/lib/formatters/${loaderOptions.formatter}`);
+    } catch (err) {
+      // Pass the formatter as-is, since it may be the module name/path of an external formatter.
+    }
   }
 
   neutrino.config

--- a/packages/eslint/test/middleware_test.js
+++ b/packages/eslint/test/middleware_test.js
@@ -33,6 +33,25 @@ test('instantiates with options', t => {
   t.notThrows(() => api.config.toConfig());
 });
 
+test('supports formatter being the name of an ESLint built-in formatter', t => {
+  const api = new Neutrino();
+  const formatter = 'compact';
+  const formatterPath = require.resolve(`eslint/lib/formatters/${formatter}`);
+  api.use(mw(), { eslint: { formatter } });
+
+  const loaderOptions = api.config.module.rule('lint').use('eslint').get('options');
+  t.is(loaderOptions.formatter, formatterPath);
+});
+
+test('supports formatter being a resolved path', t => {
+  const api = new Neutrino();
+  const formatter = require.resolve('eslint/lib/formatters/compact');
+  api.use(mw(), { eslint: { formatter } });
+
+  const loaderOptions = api.config.module.rule('lint').use('eslint').get('options');
+  t.is(loaderOptions.formatter, formatter);
+});
+
 test('exposes eslintrc output handler', t => {
   const api = new Neutrino();
 


### PR DESCRIPTION
As of webpack-contrib/eslint-loader#247 `eslint-loader` now also supports the formatter being specified as a string, rather then only as a function.

Passing as a string:
* allows the formatter to work when using `thread-loader`, which has to serialize the loader options.
* means we no longer need to manually specify `__expression`.