### PR TITLE
Allow using browserlistsrc for targets

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -389,6 +389,9 @@ For the differences between each source map type, see the [webpack devtool docs]
 Setting to `false` will override Neutrino's default targets and allow
 `@babel/preset-env` to read targets from a [`.browserslistrc` file](https://babeljs.io/docs/en/babel-preset-env#browserslist-integration).
 
+When using a `.browserslistrc` file, be aware that file changes may not
+invalidate cache as expected: https://github.com/babel/babel-loader/issues/690
+
 See [`@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env#targets)
 for all other available settings.
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -273,11 +273,6 @@ module.exports = {
         source: false
       },
 
-      // Example: Use a .browserslistrc file with @babel/preset-env
-      targets: {
-        browsers: require('browserslist')()
-      },
-
       // Remove the contents of the output directory prior to building.
       // Set to false to disable cleaning this directory
       clean: {
@@ -381,6 +376,21 @@ To customise this, use the preset's `devtool` option, for example:
 ```
 
 For the differences between each source map type, see the [webpack devtool docs](https://webpack.js.org/configuration/devtool/).
+
+### Targets
+
+```js
+['@neutrinojs/web', {
+  // Use targets from a .browserslistrc file.
+  targets: false
+}]
+```
+
+Setting to `false` will override Neutrino's default targets and allow
+`@babel/preset-env` to read targets from a [`.browserslistrc` file](https://babeljs.io/docs/en/babel-preset-env#browserslist-integration).
+
+See [`@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env#targets)
+for all other available settings.
 
 ## Hot Module Replacement
 

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -89,11 +89,6 @@ module.exports = (neutrino, opts = {}) => {
     };
   }
 
-  // Force @babel/preset-env default behavior (.browserslistrc)
-  if (options.targets === false) {
-    options.targets = {};
-  }
-
   Object.assign(options, {
     style: options.style && merge(options.style, {
       extract: options.style.extract === true ? {} : options.style.extract

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -94,7 +94,7 @@ module.exports = (neutrino, opts = {}) => {
       'last 2 iOS versions'
     ];
   }
-  
+
   Object.assign(options, {
     style: options.style && merge(options.style, {
       extract: options.style.extract === true ? {} : options.style.extract

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -39,7 +39,16 @@ module.exports = (neutrino, opts = {}) => {
       source: isProduction
     },
     babel: {},
-    targets: {},
+    targets: {
+      browsers: [
+        'last 2 Chrome versions',
+        'last 2 Firefox versions',
+        'last 2 Edge versions',
+        'last 2 Opera versions',
+        'last 2 Safari versions',
+        'last 2 iOS versions'
+      ]
+    },
     font: {},
     image: {}
   }, opts);
@@ -80,19 +89,9 @@ module.exports = (neutrino, opts = {}) => {
     };
   }
 
+  // Force @babel/preset-env default behavior (.browserslistrc)
   if (options.targets === false) {
     options.targets = {};
-  } else if (options.targets.browsers === false) {
-    Reflect.deleteProperty(options.targets, 'browsers');
-  } else if (!options.targets.node && !options.targets.browsers) {
-    options.targets.browsers = [
-      'last 2 Chrome versions',
-      'last 2 Firefox versions',
-      'last 2 Edge versions',
-      'last 2 Opera versions',
-      'last 2 Safari versions',
-      'last 2 iOS versions'
-    ];
   }
 
   Object.assign(options, {

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -39,16 +39,7 @@ module.exports = (neutrino, opts = {}) => {
       source: isProduction
     },
     babel: {},
-    targets: {
-      browsers: [
-        'last 2 Chrome versions',
-        'last 2 Firefox versions',
-        'last 2 Edge versions',
-        'last 2 Opera versions',
-        'last 2 Safari versions',
-        'last 2 iOS versions'
-      ]
-    },
+    targets: {},
     font: {},
     image: {}
   }, opts);
@@ -87,6 +78,20 @@ module.exports = (neutrino, opts = {}) => {
         }
       }
     };
+  }
+
+  // Force @babel/preset-env default behavior (.browserslistrc)
+  if (options.targets === false) {
+    options.targets = {};
+  } else if (!options.targets.node && !options.targets.browsers) {
+    options.targets.browsers = [
+      'last 2 Chrome versions',
+      'last 2 Firefox versions',
+      'last 2 Edge versions',
+      'last 2 Opera versions',
+      'last 2 Safari versions',
+      'last 2 iOS versions'
+    ];
   }
 
   Object.assign(options, {

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -80,7 +80,11 @@ module.exports = (neutrino, opts = {}) => {
     };
   }
 
-  if (!options.targets.node && !options.targets.browsers) {
+  if (options.targets === false) {
+    options.targets = {};
+  } else if (options.targets.browsers === false) {
+    Reflect.deleteProperty(options.targets, 'browsers');
+  } else if (!options.targets.node && !options.targets.browsers) {
     options.targets.browsers = [
       'last 2 Chrome versions',
       'last 2 Firefox versions',
@@ -90,7 +94,7 @@ module.exports = (neutrino, opts = {}) => {
       'last 2 iOS versions'
     ];
   }
-
+  
   Object.assign(options, {
     style: options.style && merge(options.style, {
       extract: options.style.extract === true ? {} : options.style.extract

--- a/packages/web/test/web_test.js
+++ b/packages/web/test/web_test.js
@@ -267,3 +267,28 @@ test('throws when polyfills defined', async t => {
   const err = t.throws(() => api.use(mw(), { polyfills: {} }));
   t.true(err.message.includes('The polyfills option has been removed'));
 });
+
+test('targets option test', t => {
+  const api = new Neutrino();
+  const targets = {
+    browsers: ['last 2 iOS versions']
+  };
+  api.use(mw(), { targets });
+
+  t.deepEqual(api.config.module
+    .rule('compile')
+    .use('babel')
+    .get('options')
+    .presets[0][1].targets, targets);
+});
+
+test('targets false option test', t => {
+  const api = new Neutrino();
+  api.use(mw(), { targets: false });
+
+  t.deepEqual(api.config.module
+    .rule('compile')
+    .use('babel')
+    .get('options')
+    .presets[0][1].targets, {});
+});


### PR DESCRIPTION
Resolves #1141

Allows users to pass `false` to `options.targets` or `options.targets.browsers` to have babel-env use a `.browserlistsrc` file.