### PR TITLE
compile-loader: Set 'configFile' to false by default

### DIFF
--- a/packages/compile-loader/index.js
+++ b/packages/compile-loader/index.js
@@ -11,6 +11,7 @@ module.exports = (neutrino, options = {}) => {
     .options({
       cacheDirectory: true,
       babelrc: false,
+      configFile: false,
       ...(options.babel || {})
     });
 


### PR DESCRIPTION
To prevent stray `babel.config.js` files from affecting the Neutrino babel configuration. (The existing `babelrc` option only applies to `.babelrc` files.)

See:
https://babeljs.io/docs/en/next/config-files#project-wide-configuration

Fixes #1147.