### PR TITLE
Switch to terser-webpack-plugin

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -97,15 +97,14 @@ calling out to Neutrino, or export multiple configurations from your `webpack.co
 // webpack.config.js
 const neutrino = require('neutrino');
 
+const config = neutrino().webpack();
+
 module.exports = [
   // first build configuration
-  neutrino().webpack(),
+  config,
 
   // second build configuration
-  {
-    ...neutrino().webpack(),
-   devtool: 'source-map'
-  },
+  { ...config, libraryTarget: 'commonjs2' },
 ];
 ```
 
@@ -146,8 +145,10 @@ ESLint 5, and related packages [#809](https://github.com/neutrinojs/neutrino/pul
 improved functionality around `splitChunks` [#809](https://github.com/neutrinojs/neutrino/pull/809). See
 [the split chunks documentation](https://webpack.js.org/plugins/split-chunks-plugin/) for more information.
 Usage of the `vendor` entry point will now throw an error when used with v9 and should not be used.
-- **BREAKING CHANGE** The `@neutrinojs/babel-minify` preset has been removed in favor of the much faster
-uglify-es built into webpack 4 [#809](https://github.com/neutrinojs/neutrino/pull/809).
+- **BREAKING CHANGE** The `@neutrinojs/babel-minify` preset has been removed in favor
+of the much faster `terser-webpack-plugin` (which will be the default in webpack 5)
+[#809](https://github.com/neutrinojs/neutrino/pull/809) and
+[#1158](https://github.com/neutrinojs/neutrino/pull/1158).
 - **BREAKING CHANGE** The `@neutrinojs/web` and dependent presets have renamed the `minify.babel` option
 to `minify.source` [#809](https://github.com/neutrinojs/neutrino/pull/809).
 - **BREAKING CHANGE** The `@neutrinojs/web` and dependent presets no longer include the
@@ -176,6 +177,11 @@ to RHL v4 while installing it into your project also.
 - **BREAKING CHANGE** `@neutrinojs/web`, `@neutrinojs/node`, and their dependent presets no longer configure
 defaults for copying static files at build time [#814](https://github.com/neutrinojs/neutrino/pull/814).
 Use the `@neutrinojs/copy` middleware to configure this for v9.
+- **BREAKING CHANGE** When using `@neutrinojs/web` and presets that depend on it,
+source maps must now be configured using the preset's `devtool` option rather than
+manually in a later middleware, to ensure that `terser-webpack-plugin` is configured
+correctly [#1158](https://github.com/neutrinojs/neutrino/pull/1158). See the
+[source maps documentation](./packages/web.md#source-maps) for more details.
 - **BREAKING CHANGE** Babel has been upgraded from v6 to v7 [#845](https://github.com/neutrinojs/neutrino/pull/809).
 Any additional Babel plugins and presets you use in your projects should be compatible with Babel v7 if
 they are still necessary.

--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -391,6 +391,38 @@ require(['redux', 'redux-example'], ({ createStore }, reduxExample) => {
 </script>
 ```
 
+### Source minification
+
+By default script sources are minified in production only, using
+[terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin)
+(which replaces `uglifyjs-webpack-plugin`). To customise the options passed to `TerserPlugin`
+or even use a different minifier, override `optimization.minimizer`.
+
+_Example: Adjust the `terser` minification settings:_
+
+```js
+module.exports = {
+  use: [
+    '@neutrinojs/library',
+    (neutrino) => {
+      // The `terser` minimizer plugin only exists in the configuration in production.
+      if (process.env.NODE_ENV === 'production') {
+        neutrino.config.optimization
+          .minimizer('terser')
+          .tap(([defaultOptions]) => [{
+            ...defaultOptions,
+            // https://github.com/webpack-contrib/terser-webpack-plugin#terseroptions
+            // https://github.com/terser-js/terser#minify-options
+            terserOptions: {
+              mangle: false,
+            },
+          }]);
+      }
+    }
+  ]
+};
+```
+
 ## Generating multiple builds
 
 A library can be built multiple times from a `webpack.config.js` file in order to

--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -103,6 +103,16 @@ module.exports = (neutrino, opts = {}) => {
       }
     })
     .when(process.env.NODE_ENV === 'production', (config) => {
+      // Use terser instead of the unmaintained uglify-es.
+      // This is a backport of the upcoming webpack 5 minimizer configuration:
+      // https://github.com/edmorley/webpack/blob/a94d0434a99489ef9bcb1808cdbe9cbe97bbd3e7/lib/WebpackOptionsDefaulter.js#L292-L308
+      config.optimization
+        .minimizer('terser')
+        .use(require.resolve('terser-webpack-plugin'), [{
+          cache: true,
+          parallel: true,
+          sourceMap: true
+        }]);
       config.when(options.clean, () => neutrino.use(clean, options.clean));
     });
 };

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -38,6 +38,7 @@
     "@neutrinojs/compile-loader": "9.0.0-0",
     "@neutrinojs/loader-merge": "9.0.0-0",
     "deepmerge": "^1.5.2",
+    "terser-webpack-plugin": "^1.1.0",
     "webpack-node-externals": "^1.7.2"
   },
   "peerDependencies": {

--- a/packages/library/test/library_test.js
+++ b/packages/library/test/library_test.js
@@ -46,7 +46,6 @@ test('valid preset production', t => {
   // Common
   t.is(config.target, 'web');
   t.deepEqual(config.resolve.extensions, expectedExtensions);
-  t.is(config.optimization, undefined);
   t.is(config.devServer, undefined);
   t.deepEqual(config.stats, {
     children: false,
@@ -57,6 +56,7 @@ test('valid preset production', t => {
   // NODE_ENV/command specific
   t.is(config.devtool, 'source-map');
   t.not(config.externals, undefined);
+  t.is(config.optimization.minimizer.length, 1);
 
   const errors = validate(config);
   t.is(errors.length, 0);
@@ -72,7 +72,6 @@ test('valid preset development', t => {
   // Common
   t.is(config.target, 'web');
   t.deepEqual(config.resolve.extensions, expectedExtensions);
-  t.is(config.optimization, undefined);
   t.is(config.devServer, undefined);
   t.deepEqual(config.stats, {
     children: false,
@@ -83,6 +82,7 @@ test('valid preset development', t => {
   // NODE_ENV/command specific
   t.is(config.devtool, 'source-map');
   t.not(config.externals, undefined);
+  t.is(config.optimization, undefined);
 
   const errors = validate(config);
   t.is(errors.length, 0);

--- a/packages/neutrino/handlers.js
+++ b/packages/neutrino/handlers.js
@@ -6,6 +6,31 @@ const webpack = (neutrino) => {
     );
   }
 
+  const devtool = neutrino.config.get('devtool');
+  const usingSourcemap = typeof devtool === 'string' && /source-?map/.test(devtool);
+  const minimizer = neutrino.config.optimization.minimizers.get('terser');
+  // Catch cases where the user is configuring sourcemaps outside of the web preset,
+  // since it prevents the correct configuration of `terser-webpack-plugin`. eg:
+  //   module.exports = {
+  //     use: [
+  //       '@neutrinojs/web',
+  //       (neutrino) => neutrino.config.devtool('source-map'),
+  //     ]
+  //   };
+  // This cannot occur when using the node or library presets, since they unconditionally
+  // set sourceMap to `true`. If a project wants to configure neutrino.config.devtool but
+  // disable source maps in terser-webpack-plugin, then they can unset `sourceMap` rather
+  // than setting it to `false`.
+  if (usingSourcemap && minimizer && (minimizer.get('args')[0] || {}).sourceMap === false) {
+    throw new Error(
+      `neutrino.config.devtool is set to '${devtool}', however terser-webpack-plugin ` +
+      'has not been correctly configured to allow source maps. ' +
+      'This can happen if the devtool is configured manually outside of the preset. ' +
+      'Use the web/react/vue/... preset\'s new `devtool` option instead. See:\n' +
+      'https://neutrinojs.org/packages/web/#source-maps'
+    );
+  }
+
   return neutrino.config.toConfig();
 };
 

--- a/packages/neutrino/test/package_test.js
+++ b/packages/neutrino/test/package_test.js
@@ -41,6 +41,20 @@ test('throws when vendor entrypoint defined', t => {
   );
 });
 
+test('throws if devtool configured manually when using terser-webpack-plugin', t => {
+  process.env.NODE_ENV = 'production';
+  const mw = (neutrino) =>
+    neutrino.config
+      .devtool('source-map')
+      .optimization
+        .minimizer('terser')
+          .use(Function.prototype, [{ sourceMap: false }]);
+  t.throws(
+    () => neutrino(mw).output('webpack'),
+    /terser-webpack-plugin has not been correctly configured/
+  );
+});
+
 test('throws when trying to use a non-registered output', t => {
   t.throws(
     () => neutrino(Function.prototype).output('fake'),

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -313,6 +313,38 @@ If the need arises, you can also compile `node_modules` by referring to the rele
 This preset automatically vendors all external dependencies into a separate chunk based on their inclusion in your
 package.json. No extra work is required to make this work.
 
+### Source minification
+
+By default script sources are minified in production only, using
+[terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin)
+(which replaces `uglifyjs-webpack-plugin`). To customise the options passed to `TerserPlugin`
+or even use a different minifier, override `optimization.minimizer`.
+
+_Example: Adjust the `terser` minification settings:_
+
+```js
+module.exports = {
+  use: [
+    '@neutrinojs/node',
+    (neutrino) => {
+      // The `terser` minimizer plugin only exists in the configuration in production.
+      if (process.env.NODE_ENV === 'production') {
+        neutrino.config.optimization
+          .minimizer('terser')
+          .tap(([defaultOptions]) => [{
+            ...defaultOptions,
+            // https://github.com/webpack-contrib/terser-webpack-plugin#terseroptions
+            // https://github.com/terser-js/terser#minify-options
+            terserOptions: {
+              mangle: false,
+            },
+          }]);
+      }
+    }
+  ]
+};
+```
+
 ### Rules
 
 The following is a list of rules and their identifiers which can be overridden:

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -106,6 +106,16 @@ module.exports = (neutrino, opts = {}) => {
         });
     })
     .when(process.env.NODE_ENV === 'production', (config) => {
+      // Use terser instead of the unmaintained uglify-es.
+      // This is a backport of the upcoming webpack 5 minimizer configuration:
+      // https://github.com/edmorley/webpack/blob/a94d0434a99489ef9bcb1808cdbe9cbe97bbd3e7/lib/WebpackOptionsDefaulter.js#L292-L308
+      config.optimization
+        .minimizer('terser')
+        .use(require.resolve('terser-webpack-plugin'), [{
+          cache: true,
+          parallel: true,
+          sourceMap: true
+        }]);
       config.when(options.clean, () => neutrino.use(clean, options.clean));
     });
 };

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -32,6 +32,7 @@
     "@neutrinojs/start-server": "9.0.0-0",
     "deepmerge": "^1.5.2",
     "lodash.omit": "^4.5.0",
+    "terser-webpack-plugin": "^1.1.0",
     "webpack-node-externals": "^1.7.2"
   },
   "peerDependencies": {

--- a/packages/node/test/node_test.js
+++ b/packages/node/test/node_test.js
@@ -37,7 +37,6 @@ test('valid preset production', t => {
   // Common
   t.is(config.target, 'node');
   t.deepEqual(config.resolve.extensions, expectedExtensions);
-  t.is(config.optimization, undefined);
   t.is(config.devServer, undefined);
   t.deepEqual(config.stats, {
     children: false,
@@ -47,6 +46,7 @@ test('valid preset production', t => {
 
   // NODE_ENV/command specific
   t.is(config.devtool, 'source-map');
+  t.is(config.optimization.minimizer.length, 1);
 
   const errors = validate(config);
   t.is(errors.length, 0);
@@ -61,7 +61,6 @@ test('valid preset development', t => {
   // Common
   t.is(config.target, 'node');
   t.deepEqual(config.resolve.extensions, expectedExtensions);
-  t.is(config.optimization, undefined);
   t.is(config.devServer, undefined);
   t.deepEqual(config.stats, {
     children: false,
@@ -71,6 +70,7 @@ test('valid preset development', t => {
 
   // NODE_ENV/command specific
   t.is(config.devtool, 'inline-sourcemap');
+  t.is(config.optimization, undefined);
 
   const errors = validate(config);
   t.is(errors.length, 0);

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -536,38 +536,31 @@ module.exports = {
 
 #### Source minification
 
-By default script sources are minified in production only, and using webpack's default of
-[uglifyjs-webpack-plugin](https://github.com/webpack-contrib/uglifyjs-webpack-plugin)
-(which internally uses `uglify-es`). To customise the options passed to `UglifyJsPlugin`
+By default script sources are minified in production only, using
+[terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin)
+(which replaces `uglifyjs-webpack-plugin`). To customise the options passed to `TerserPlugin`
 or even use a different minifier, override `optimization.minimizer`.
 
-Note: If switching to [babel-minify-webpack-plugin](https://github.com/webpack-contrib/babel-minify-webpack-plugin)
-ensure that sourcemaps are disabled in production to avoid [this bug](https://github.com/webpack-contrib/babel-minify-webpack-plugin/issues/68).
-
-_Example: Use different options with `uglify-es`:_
+_Example: Adjust the `terser` minification settings:_
 
 ```js
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
-
 module.exports = {
   use: [
     '@neutrinojs/web',
     (neutrino) => {
-      neutrino.config
-        .optimization
-          .minimizer([
-            // Based on:
-            // https://github.com/webpack/webpack/blob/v4.6.0/lib/WebpackOptionsDefaulter.js#L277-L285
-            new UglifyJsPlugin({
-              cache: true,
-              parallel: true,
-              sourceMap: neutrino.config.devtool && /source-?map/.test(neutrino.config.devtool),
-              uglifyOptions: {
-                // Custom uglify-es options here. See:
-                // https://github.com/mishoo/UglifyJS2/tree/harmony#minify-options
-              }
-            })
-          ]);
+      // The `terser` minimizer plugin only exists in the configuration in production.
+      if (process.env.NODE_ENV === 'production') {
+        neutrino.config.optimization
+          .minimizer('terser')
+          .tap(([defaultOptions]) => [{
+            ...defaultOptions,
+            // https://github.com/webpack-contrib/terser-webpack-plugin#terseroptions
+            // https://github.com/terser-js/terser#minify-options
+            terserOptions: {
+              mangle: false,
+            },
+          }]);
+      }
     }
   ]
 };

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -163,6 +163,18 @@ module.exports = (neutrino, opts = {}) => {
   neutrino.config
     .optimization
       .minimize(options.minify.source)
+      // Use terser instead of the unmaintained uglify-es.
+      // This is a backport of the upcoming webpack 5 minimizer configuration:
+      // https://github.com/edmorley/webpack/blob/a94d0434a99489ef9bcb1808cdbe9cbe97bbd3e7/lib/WebpackOptionsDefaulter.js#L292-L308
+      .when(options.minify.source, (optimization) =>
+        optimization
+          .minimizer('terser')
+          .use(require.resolve('terser-webpack-plugin'), [{
+            cache: true,
+            parallel: true,
+            sourceMap: typeof devtool === 'string' && /source-?map/.test(devtool)
+          }])
+       )
       .splitChunks({
         // By default SplitChunksPlugin only splits out the async chunks (to avoid the
         // ever-changing file list breaking users who don't auto-generate their HTML):

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,6 +36,7 @@
     "@neutrinojs/loader-merge": "9.0.0-0",
     "@neutrinojs/style-loader": "9.0.0-0",
     "deepmerge": "^1.5.2",
+    "terser-webpack-plugin": "^1.1.0",
     "webpack-manifest-plugin": "^2.0.4"
   },
   "peerDependencies": {

--- a/packages/web/test/web_test.js
+++ b/packages/web/test/web_test.js
@@ -41,6 +41,7 @@ test('valid preset production', t => {
 
   // NODE_ENV/command specific
   t.true(config.optimization.minimize);
+  t.is(config.optimization.minimizer.length, 1);
   t.false(config.optimization.splitChunks.name);
   t.is(config.devtool, undefined);
   t.is(config.devServer, undefined);
@@ -68,6 +69,7 @@ test('valid preset development', t => {
 
   // NODE_ENV/command specific
   t.false(config.optimization.minimize);
+  t.is(config.optimization.minimizer, undefined);
   t.true(config.optimization.splitChunks.name);
   t.is(config.devtool, 'cheap-module-eval-source-map');
   t.not(config.devServer, undefined);
@@ -105,6 +107,7 @@ test('valid preset test', t => {
 
   // NODE_ENV/command specific
   t.false(config.optimization.minimize);
+  t.is(config.optimization.minimizer, undefined);
   t.true(config.optimization.splitChunks.name);
   t.is(config.devtool, 'source-map');
   t.is(config.devServer, undefined);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2200,6 +2200,26 @@ cacache@^10.0.4:
     unique-filename "^1.1.0"
     y18n "^4.0.0"
 
+cacache@^11.0.2:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.2.0.tgz#617bdc0b02844af56310e411c0878941d5739965"
+  integrity sha512-IFWl6lfK6wSeYCHUXh+N1lY72UDrpyrYQJNIVQf48paDuWbv5RbAtJYf/4gUQFObTCHZwdZ5sI8Iw7nqwP6nlQ==
+  dependencies:
+    bluebird "^3.5.1"
+    chownr "^1.0.1"
+    figgy-pudding "^3.1.0"
+    glob "^7.1.2"
+    graceful-fs "^4.1.11"
+    lru-cache "^4.1.3"
+    mississippi "^3.0.0"
+    mkdirp "^0.5.1"
+    move-concurrently "^1.0.1"
+    promise-inflight "^1.0.1"
+    rimraf "^2.6.2"
+    ssri "^6.0.0"
+    unique-filename "^1.1.0"
+    y18n "^4.0.0"
+
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -4811,6 +4831,11 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+figgy-pudding@^3.1.0, figgy-pudding@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
+  integrity sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==
+
 figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -4919,6 +4944,15 @@ find-cache-dir@^1.0.0:
     commondir "^1.0.1"
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
+
+find-cache-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.0.0.tgz#4c1faed59f45184530fb9d7fa123a4d04a98472d"
+  integrity sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^1.0.0"
+    pkg-dir "^3.0.0"
 
 find-parent-dir@^0.3.0:
   version "0.3.0"
@@ -7733,7 +7767,7 @@ lru-cache@2.2.x:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.2.4.tgz#6c658619becf14031d0d0b594b16042ce4dc063d"
   integrity sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=
 
-lru-cache@^4.0.1, lru-cache@^4.1.1, lru-cache@^4.1.2:
+lru-cache@^4.0.1, lru-cache@^4.1.1, lru-cache@^4.1.2, lru-cache@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
   integrity sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==
@@ -8150,6 +8184,22 @@ mississippi@^2.0.0:
     from2 "^2.1.0"
     parallel-transform "^1.1.0"
     pump "^2.0.1"
+    pumpify "^1.3.3"
+    stream-each "^1.1.0"
+    through2 "^2.0.0"
+
+mississippi@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-3.0.0.tgz#ea0a3291f97e0b5e8776b363d5f0a12d94c67022"
+  integrity sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==
+  dependencies:
+    concat-stream "^1.5.0"
+    duplexify "^3.4.2"
+    end-of-stream "^1.1.0"
+    flush-write-stream "^1.0.0"
+    from2 "^2.1.0"
+    parallel-transform "^1.1.0"
+    pump "^3.0.0"
     pumpify "^1.3.3"
     stream-each "^1.1.0"
     through2 "^2.0.0"
@@ -9641,6 +9691,14 @@ pump@^2.0.0, pump@^2.0.1:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 pumpify@^1.3.3:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.1.tgz#36513be246ab27570b1a374a5ce278bfd74370ce"
@@ -10808,7 +10866,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.6, source-map-support@^0.5.9:
+source-map-support@^0.5.6, source-map-support@^0.5.9, source-map-support@~0.5.6:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
   integrity sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==
@@ -10944,6 +11002,13 @@ ssri@^5.2.4:
   integrity sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==
   dependencies:
     safe-buffer "^5.1.1"
+
+ssri@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
+  integrity sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==
+  dependencies:
+    figgy-pudding "^3.5.1"
 
 stable@~0.1.6:
   version "0.1.8"
@@ -11320,6 +11385,29 @@ term-size@^1.2.0:
   integrity sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=
   dependencies:
     execa "^0.7.0"
+
+terser-webpack-plugin@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.1.0.tgz#cf7c25a1eee25bf121f4a587bb9e004e3f80e528"
+  integrity sha512-61lV0DSxMAZ8AyZG7/A4a3UPlrbOBo8NIQ4tJzLPAdGOQ+yoNC7l5ijEow27lBAL2humer01KLS6bGIMYQxKoA==
+  dependencies:
+    cacache "^11.0.2"
+    find-cache-dir "^2.0.0"
+    schema-utils "^1.0.0"
+    serialize-javascript "^1.4.0"
+    source-map "^0.6.1"
+    terser "^3.8.1"
+    webpack-sources "^1.1.0"
+    worker-farm "^1.5.2"
+
+terser@^3.8.1:
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-3.9.3.tgz#14d13207f58b7a25ba7dd11def76c9e73cca5036"
+  integrity sha512-7CAUcdTRzfxvMUqhSDe95MQ/qVEV3JqiSB8mMGQZSe1CL7AKB1iMpF7Mj6DatC9YfG/4xxE25Egp1kxVNORdGQ==
+  dependencies:
+    commander "~2.17.1"
+    source-map "~0.6.1"
+    source-map-support "~0.5.6"
 
 test-exclude@^4.2.1:
   version "4.2.3"


### PR DESCRIPTION
Since the webpack 4 default of `uglifyjs-webpack-plugin` uses `uglify-es`, which has been deprecated in favour of `terser`. webpack 5 is due to use `terser-webpack-plugin`, at which point we can remove this.

`terser` includes multiple correctness and performance fixes not present in `uglify-es`.

Fixes #1146.