### PR TITLE
tests: Clean up t.throws() and async usage

### DIFF
--- a/packages/eslint/test/middleware_test.js
+++ b/packages/eslint/test/middleware_test.js
@@ -76,7 +76,7 @@ test('exposes eslintrc config from method', t => {
   t.is(typeof neutrino(mw()).eslintrc(), 'object');
 });
 
-test('throws when used after a compile preset', async t => {
+test('throws when used after a compile preset', t => {
   const api = new Neutrino();
   api.use(require('../../web'));
 

--- a/packages/library/test/library_test.js
+++ b/packages/library/test/library_test.js
@@ -24,15 +24,16 @@ test('uses preset', t => {
 test('throws when missing library name', t => {
   const api = new Neutrino();
 
-  const err = t.throws(() => api.use(mw()));
-  t.true(err.message.includes('You must specify a library name'));
+  t.throws(() => api.use(mw()), /You must specify a library name/);
 });
 
-test('throws when polyfills defined', async t => {
+test('throws when polyfills defined', t => {
   const api = new Neutrino();
 
-  const err = t.throws(() => api.use(mw(), { name: 'alpha', polyfills: {} }));
-  t.true(err.message.includes('The polyfills option has been removed'));
+  t.throws(
+    () => api.use(mw(), { name: 'alpha', polyfills: {} }),
+    /The polyfills option has been removed/
+  );
 });
 
 test('valid preset production', t => {

--- a/packages/neutrino/test/package_test.js
+++ b/packages/neutrino/test/package_test.js
@@ -34,29 +34,25 @@ test('undefined mode and NODE_ENV sets only NODE_ENV', t => {
 });
 
 test('throws when vendor entrypoint defined', t => {
-  const err = t.throws(() => {
-    neutrino(neutrino => {
-      neutrino.config.entry('vendor').add('lodash');
-    }).output('webpack');
-  });
-
-  t.true(err.message.includes('Remove the manual `vendor` entrypoint'));
+  const mw = (neutrino) => neutrino.config.entry('vendor').add('lodash');
+  t.throws(
+    () => neutrino(mw).output('webpack'),
+    /Remove the manual `vendor` entrypoint/
+  );
 });
 
 test('throws when trying to use a non-registered output', t => {
-  const err = t.throws(() =>
-    neutrino(Function.prototype).output('fake')
+  t.throws(
+    () => neutrino(Function.prototype).output('fake'),
+    'Unable to find an output handler named "fake"'
   );
-
-  t.true(err.message.includes('Unable to find an output handler'));
 });
 
 test('throws when trying to use a non-registered proxied method', t => {
-  const err = t.throws(() =>
-    neutrino(Function.prototype).fake()
+  t.throws(
+    () => neutrino(Function.prototype).fake(),
+    'Unable to find an output handler named "fake"'
   );
-
-  t.true(err.message.includes('Unable to find an output handler'));
 });
 
 test('exposes webpack output handler', t => {

--- a/packages/neutrino/test/require_test.js
+++ b/packages/neutrino/test/require_test.js
@@ -16,10 +16,10 @@ test('requires middleware from root/node_modules', t => {
   t.notThrows(() => new Neutrino().use('alpha'));
 });
 
-test('forks with error middleware contains error', (t) => {
-  t.throws(() => new Neutrino().use('errorMiddleware'));
+test('throws if middleware contains error', (t) => {
+  t.throws(() => new Neutrino().use('errorMiddleware'), SyntaxError);
 });
 
 test('throws if middleware cannot be found', (t) => {
-  t.throws(() => new Neutrino().use('nonExistent'));
+  t.throws(() => new Neutrino().use('nonExistent'), 'Cannot find module \'nonExistent\'');
 });

--- a/packages/node/test/node_test.js
+++ b/packages/node/test/node_test.js
@@ -76,7 +76,7 @@ test('valid preset development', t => {
   t.is(errors.length, 0);
 });
 
-test('throws when polyfills defined', async t => {
+test('throws when polyfills defined', t => {
   const api = new Neutrino();
 
   const err = t.throws(() => api.use(mw(), { polyfills: {} }));

--- a/packages/web/test/web_test.js
+++ b/packages/web/test/web_test.js
@@ -240,28 +240,28 @@ test('supports multiple mains with custom html-webpack-plugin options', t => {
   }]);
 });
 
-test('throws when minify.babel defined', async t => {
+test('throws when minify.babel defined', t => {
   const api = new Neutrino();
 
   const err = t.throws(() => api.use(mw(), { minify: { babel: false } }));
   t.true(err.message.includes('The minify.babel option has been removed'));
 });
 
-test('throws when minify.image defined', async t => {
+test('throws when minify.image defined', t => {
   const api = new Neutrino();
 
   const err = t.throws(() => api.use(mw(), { minify: { image: true } }));
   t.true(err.message.includes('The minify.image option has been removed'));
 });
 
-test('throws when minify.style defined', async t => {
+test('throws when minify.style defined', t => {
   const api = new Neutrino();
 
   const err = t.throws(() => api.use(mw(), { minify: { style: false } }));
   t.true(err.message.includes('The minify.style option has been removed'));
 });
 
-test('throws when polyfills defined', async t => {
+test('throws when polyfills defined', t => {
   const api = new Neutrino();
 
   const err = t.throws(() => api.use(mw(), { polyfills: {} }));


### PR DESCRIPTION
* The error message can be checked by `t.throws()` itself, so no need for a separate assertion for that afterwards.
* We were marking several tests as async that were actually not.