### PR TITLE
Improvements to the Neutrino 9 migration UX

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -39,12 +39,15 @@ neutrino --inspect --mode production > v9.config
 git diff --no-index v8.config v9.config
 ```
 
-Please [file an issue](https://github.com/neutrinojs/neutrino/issues) if any issue arises from upgrade
-that may not be outlined here.
+**We strongly recommend that any Yarn/NPM lockfiles (eg `yarn.lock` or `package-lock.json`) are
+removed and regenerated when upgrading, to prevent problems caused by leftover dependencies.**
+
+Please [file an issue](https://github.com/neutrinojs/neutrino/issues) if any issue arises from the
+upgrade that may not be outlined here.
 
 A list of changes is detailed below for migrating:
 
-- **BREAKING CHANGE** The minimum supported Node.js version is 8.10. Node.js 9 is no longer supported
+- **BREAKING CHANGE** The minimum supported Node.js version is 8.10. Node.js 6 and 9 are no longer supported
 [#792](https://github.com/neutrinojs/neutrino/pull/792).
 - **BREAKING CHANGE** Consumption of middleware and presets are now dependent on the external CLIs and
 configuration files for which they are intended [#852](https://github.com/neutrinojs/neutrino/pull/852).

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -39,7 +39,7 @@ neutrino --inspect --mode production > v9.config
 git diff --no-index v8.config v9.config
 ```
 
-**We strongly recommend that any Yarn/NPM lockfiles (eg `yarn.lock` or `package-lock.json`) are
+**We strongly recommend that any Yarn/npm lockfiles (eg `yarn.lock` or `package-lock.json`) are
 removed and regenerated when upgrading, to prevent problems caused by leftover dependencies.**
 
 Please [file an issue](https://github.com/neutrinojs/neutrino/issues) if any issue arises from the

--- a/packages/html-template/index.js
+++ b/packages/html-template/index.js
@@ -5,7 +5,7 @@ module.exports = (neutrino, { pluginId = 'html', ...options } = {}) => {
     throw new Error(
       'The default Neutrino HTML template no longer supports the "links" option. ' +
       'To set a favicon use the "favicon" option instead. For stylesheets either ' +
-      'import the equivalent NPM package from JS, or if using a CDN is preferred, ' +
+      'import the equivalent npm package from JS, or if using a CDN is preferred, ' +
       'then copy the default HTML template into your repository (where it can be ' +
       'customised as desired) and set the "template" option to its path.'
     );

--- a/packages/html-template/index.js
+++ b/packages/html-template/index.js
@@ -1,6 +1,16 @@
 const { resolve } = require('path');
 
 module.exports = (neutrino, { pluginId = 'html', ...options } = {}) => {
+  if ('links' in options && !('template' in options)) {
+    throw new Error(
+      'The default Neutrino HTML template no longer supports the "links" option. ' +
+      'To set a favicon use the "favicon" option instead. For stylesheets either ' +
+      'import the equivalent NPM package from JS, or if using a CDN is preferred, ' +
+      'then copy the default HTML template into your repository (where it can be ' +
+      'customised as desired) and set the "template" option to its path.'
+    );
+  }
+
   neutrino.config
     .plugin(pluginId)
     .use(require.resolve('html-webpack-plugin'), [

--- a/packages/html-template/test/middleware_test.js
+++ b/packages/html-template/test/middleware_test.js
@@ -35,3 +35,18 @@ test('instantiates with options', t => {
 
   t.notThrows(() => api.config.toConfig());
 });
+
+test('throws when links defined with default template', t => {
+  const api = new Neutrino();
+
+  t.throws(
+    () => api.use(mw(), { links: [] }),
+    /no longer supports the "links" option/
+  );
+});
+
+test('does not throw when links defined with custom template', t => {
+  const api = new Neutrino();
+
+  t.notThrows(() => api.use(mw(), { links: [], template: 'custom.html' }));
+});

--- a/packages/neutrino/bin/neutrino.js
+++ b/packages/neutrino/bin/neutrino.js
@@ -11,11 +11,12 @@ if (argv.inspect) {
 }
 
 console.error(`
-The "neutrino start/build/lint" commands have been removed starting with v9.
-Please see the migration guide at https://neutrinojs.org/migration-guide
-for details on upgrading your installation.
+The "neutrino start/build/lint/test" commands were removed in Neutrino 9.
+Please see the migration guide for how to upgrade your project:
+https://neutrinojs.org/migration-guide/
 
-You may still inspect the generated webpack configuration with "neutrino --inspect".
+You may still inspect the generated webpack configuration using:
+neutrino --inspect --mode {production,development}
 `);
 
 process.exit(1);

--- a/packages/node/test/node_test.js
+++ b/packages/node/test/node_test.js
@@ -78,7 +78,8 @@ test('valid preset development', t => {
 
 test('throws when polyfills defined', t => {
   const api = new Neutrino();
-
-  const err = t.throws(() => api.use(mw(), { polyfills: {} }));
-  t.true(err.message.includes('The polyfills option has been removed'));
+  t.throws(
+    () => api.use(mw(), { polyfills: {} }),
+    /The polyfills option has been removed/
+  );
 });

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -49,7 +49,7 @@ module.exports = (neutrino, opts = {}) => {
   }
 
   if ('image' in options.minify) {
-    throw new Error('The minify.image option has been removed. To enable image minification use the @neutrinojs/image-minify preset.');
+    throw new Error('The minify.image option has been removed. See: https://github.com/neutrinojs/neutrino/issues/1104');
   }
 
   if ('style' in options.minify) {
@@ -58,6 +58,13 @@ module.exports = (neutrino, opts = {}) => {
 
   if ('polyfills' in options) {
     throw new Error('The polyfills option has been removed, since polyfills are no longer included by default.');
+  }
+
+  if ('hotEntries' in options) {
+    throw new Error(
+      'The hotEntries option has been removed. See the "neutrino.options.mains" ' +
+      'docs for how to add custom hot entries to your bundle without importing.'
+    );
   }
 
   if (typeof options.devtool === 'string' || typeof options.devtool === 'boolean') {
@@ -212,14 +219,6 @@ module.exports = (neutrino, opts = {}) => {
       neutrino.use(devServer, options.devServer);
       config.when(options.hot, (config) => {
         config.plugin('hot').use(require.resolve('webpack/lib/HotModuleReplacementPlugin'));
-
-        if ('hotEntries' in options) {
-          throw new Error(
-            'The options.hotEntries option has been removed. ' +
-            'See the "neutrino.options.mains" docs for details on adding ' +
-            'custom hot entries to your bundle without importing.'
-          );
-        }
       });
     })
     .when(isProduction, (config) => {

--- a/packages/web/test/web_test.js
+++ b/packages/web/test/web_test.js
@@ -242,30 +242,42 @@ test('supports multiple mains with custom html-webpack-plugin options', t => {
 
 test('throws when minify.babel defined', t => {
   const api = new Neutrino();
-
-  const err = t.throws(() => api.use(mw(), { minify: { babel: false } }));
-  t.true(err.message.includes('The minify.babel option has been removed'));
+  t.throws(
+    () => api.use(mw(), { minify: { babel: false } }),
+    /The minify\.babel option has been removed/
+  );
 });
 
 test('throws when minify.image defined', t => {
   const api = new Neutrino();
-
-  const err = t.throws(() => api.use(mw(), { minify: { image: true } }));
-  t.true(err.message.includes('The minify.image option has been removed'));
+  t.throws(
+    () => api.use(mw(), { minify: { image: true } }),
+    /The minify\.image option has been removed/
+  );
 });
 
 test('throws when minify.style defined', t => {
   const api = new Neutrino();
-
-  const err = t.throws(() => api.use(mw(), { minify: { style: false } }));
-  t.true(err.message.includes('The minify.style option has been removed'));
+  t.throws(
+    () => api.use(mw(), { minify: { style: false } }),
+    /The minify\.style option has been removed/
+  );
 });
 
 test('throws when polyfills defined', t => {
   const api = new Neutrino();
+  t.throws(
+    () => api.use(mw(), { polyfills: {} }),
+    /The polyfills option has been removed/
+  );
+});
 
-  const err = t.throws(() => api.use(mw(), { polyfills: {} }));
-  t.true(err.message.includes('The polyfills option has been removed'));
+test('throws when hotEntries defined', t => {
+  const api = new Neutrino();
+  t.throws(
+    () => api.use(mw(), { hotEntries: [] }),
+    /The hotEntries option has been removed/
+  );
 });
 
 test('targets option test', t => {


### PR DESCRIPTION
* An error is now shown when using the `links` HTML option without also specifying a custom template, so that users affected by #1049 know what changes they need to make. See:
  https://github.com/neutrinojs/neutrino/issues/1129#issuecomment-428169383
* The migration guide now recommends regenerating the lockfiles.
* The migration section about supported Node.js versions has been made clearer. See:
  https://github.com/neutrinojs/neutrino/issues/1129#issuecomment-423796131
* The `neutrino` bin script error message now mentions `test` being removed, includes `--mode` for the inspect example, and uses the correct URL for the migration guide.
* The `minify.image` option deprecation error message no longer refers to `@neutrinojs/image-minify`, since it was removed. I've linked to the issue since it gives more background as to why compile-time minification is not recommended.
* The `hotEntries` option deprecation check now always occurs, and not only when `options.hot` is enabled. A test has also been added.