### PR TITLE
Add checks for middleware being used twice unintentionally

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -218,6 +218,9 @@ configuration via a configuration file, you can set it to `true` via `babel: { b
 - **BREAKING CHANGE** `@neutrinojs/eslint` and dependent middleware now throw if they are used by Neutrino after
 a compile preset [#839](https://github.com/neutrinojs/neutrino/pull/939). This is to prevent using an unknowingly
 broken configuration.
+- **BREAKING CHANGE** Most Neutrino middleware now throws if used twice with the same rule IDs. This is to
+prevent mis-configurations seen in the wild (such as using both `@neutrinojs/web` and one of the lower-level
+middleware it uses at the same time) [#1162](https://github.com/neutrinojs/neutrino/pull/1162).
 - **BREAKING CHANGE** The `@neutrinojs/mocha` preset no longer accepts middleware options as Mocha's CLI does not
 allow providing an options file which can call out to Neutrino to load middleware
 [#852](https://github.com/neutrinojs/neutrino/pull/852). Manually pass any Mocha options to a [`mocha.opts`](https://mochajs.org/#mochaopts)

--- a/packages/compile-loader/index.js
+++ b/packages/compile-loader/index.js
@@ -1,13 +1,9 @@
 const babelMerge = require('babel-merge');
+const { DuplicateRuleError } = require('neutrino/errors');
 
 module.exports = (neutrino, { ruleId = 'compile', useId = 'babel', ...options } = {}) => {
   if (neutrino.config.module.rules.has(ruleId)) {
-    throw new Error(
-      '@neutrinojs/compile-loader has been used twice with the same `ruleId`.\n' +
-      'If you are including this preset manually to customise the compile rules\n' +
-      "configured by another preset, instead use that preset's own options to do so\n" +
-      '(such as the `babel` option when using the Neutrino web/react/node/... presets).'
-    );
+    throw new DuplicateRuleError('@neutrinojs/compile-loader', ruleId);
   }
 
   neutrino.config.module

--- a/packages/compile-loader/index.js
+++ b/packages/compile-loader/index.js
@@ -1,12 +1,21 @@
 const babelMerge = require('babel-merge');
 
-module.exports = (neutrino, options = {}) => {
+module.exports = (neutrino, { ruleId = 'compile', useId = 'babel', ...options } = {}) => {
+  if (neutrino.config.module.rules.has(ruleId)) {
+    throw new Error(
+      '@neutrinojs/compile-loader has been used twice with the same `ruleId`.\n' +
+      'If you are including this preset manually to customise the compile rules\n' +
+      "configured by another preset, instead use that preset's own options to do so\n" +
+      '(such as the `babel` option when using the Neutrino web/react/node/... presets).'
+    );
+  }
+
   neutrino.config.module
-    .rule(options.ruleId || 'compile')
+    .rule(ruleId)
     .test(options.test || neutrino.regexFromExtensions())
     .when(options.include, rule => rule.include.merge(options.include))
     .when(options.exclude, rule => rule.exclude.merge(options.exclude))
-    .use(options.useId || 'babel')
+    .use(useId)
     .loader(require.resolve('babel-loader'))
     .options({
       cacheDirectory: true,
@@ -17,8 +26,8 @@ module.exports = (neutrino, options = {}) => {
 
   neutrino.register('babel', (neutrino) =>
     neutrino.config.module
-      .rule('compile')
-      .use('babel')
+      .rule(ruleId)
+      .use(useId)
       .get('options')
   );
 };

--- a/packages/compile-loader/test/middleware_test.js
+++ b/packages/compile-loader/test/middleware_test.js
@@ -64,5 +64,8 @@ test('exposes babel config from method', t => {
 test('throws when used twice', t => {
   const api = new Neutrino();
   api.use(mw());
-  t.throws(() => api.use(mw()), /@neutrinojs\/compile-loader has been used twice/);
+  t.throws(
+    () => api.use(mw()),
+    /@neutrinojs\/compile-loader has been used twice with the same ruleId of 'compile'/
+  );
 });

--- a/packages/compile-loader/test/middleware_test.js
+++ b/packages/compile-loader/test/middleware_test.js
@@ -60,3 +60,9 @@ test('exposes babel method', t => {
 test('exposes babel config from method', t => {
   t.is(typeof neutrino(mw()).babel(), 'object');
 });
+
+test('throws when used twice', t => {
+  const api = new Neutrino();
+  api.use(mw());
+  t.throws(() => api.use(mw()), /@neutrinojs\/compile-loader has been used twice/);
+});

--- a/packages/eslint/index.js
+++ b/packages/eslint/index.js
@@ -80,6 +80,14 @@ module.exports = (neutrino, opts = {}) => {
     throw new Error('Lint presets must be defined prior to any other presets in .neutrinorc.js.');
   }
 
+  if (neutrino.config.module.rules.has('lint')) {
+    throw new Error(
+      '@neutrinojs/eslint has been used twice.\n' +
+      'If you are including this preset manually to customise the ESLint rule\n' +
+      "configured by another preset, instead use that preset's own options to do so."
+    );
+  }
+
   const defaults = {
     include: !opts.include ? [neutrino.options.source, neutrino.options.tests] : undefined,
     eslint: {

--- a/packages/eslint/index.js
+++ b/packages/eslint/index.js
@@ -1,7 +1,7 @@
 const deepmerge = require('deepmerge');
 const clone = require('lodash.clonedeep');
 const omit = require('lodash.omit');
-const { DuplicateRuleError } = require('neutrino/errors');
+const { ConfigurationError, DuplicateRuleError } = require('neutrino/errors');
 
 const merge = (source, destination) => {
   const sourceRules = (source && source.eslint && source.eslint.rules) || {};
@@ -78,7 +78,9 @@ const eslintrc = (neutrino) => {
 
 module.exports = (neutrino, opts = {}) => {
   if (neutrino.config.module.rules.has('compile')) {
-    throw new Error('Lint presets must be defined prior to any other presets in .neutrinorc.js.');
+    throw new ConfigurationError(
+      'Lint presets must be defined prior to any other presets in .neutrinorc.js.'
+    );
   }
 
   if (neutrino.config.module.rules.has('lint')) {

--- a/packages/eslint/index.js
+++ b/packages/eslint/index.js
@@ -1,6 +1,7 @@
 const deepmerge = require('deepmerge');
 const clone = require('lodash.clonedeep');
 const omit = require('lodash.omit');
+const { DuplicateRuleError } = require('neutrino/errors');
 
 const merge = (source, destination) => {
   const sourceRules = (source && source.eslint && source.eslint.rules) || {};
@@ -81,11 +82,7 @@ module.exports = (neutrino, opts = {}) => {
   }
 
   if (neutrino.config.module.rules.has('lint')) {
-    throw new Error(
-      '@neutrinojs/eslint has been used twice.\n' +
-      'If you are including this preset manually to customise the ESLint rule\n' +
-      "configured by another preset, instead use that preset's own options to do so."
-    );
+    throw new DuplicateRuleError('@neutrinojs/eslint', 'lint');
   }
 
   const defaults = {

--- a/packages/eslint/test/middleware_test.js
+++ b/packages/eslint/test/middleware_test.js
@@ -82,3 +82,9 @@ test('throws when used after a compile preset', t => {
 
   t.throws(() => api.use(mw()), /Lint presets must be defined prior/);
 });
+
+test('throws when used twice', t => {
+  const api = new Neutrino();
+  api.use(mw());
+  t.throws(() => api.use(mw()), /@neutrinojs\/eslint has been used twice/);
+});

--- a/packages/eslint/test/middleware_test.js
+++ b/packages/eslint/test/middleware_test.js
@@ -86,5 +86,8 @@ test('throws when used after a compile preset', t => {
 test('throws when used twice', t => {
   const api = new Neutrino();
   api.use(mw());
-  t.throws(() => api.use(mw()), /@neutrinojs\/eslint has been used twice/);
+  t.throws(
+    () => api.use(mw()),
+    /@neutrinojs\/eslint has been used twice with the same ruleId of 'lint'/
+  );
 });

--- a/packages/font-loader/index.js
+++ b/packages/font-loader/index.js
@@ -1,3 +1,5 @@
+const { DuplicateRuleError } = require('neutrino/errors');
+
 module.exports = (neutrino, options = {}) => {
   const ruleId = 'font';
   const isProduction = process.env.NODE_ENV === 'production';
@@ -6,12 +8,7 @@ module.exports = (neutrino, options = {}) => {
   };
 
   if (neutrino.config.module.rules.has(ruleId)) {
-    throw new Error(
-      '@neutrinojs/font-loader has been used twice.\n' +
-      'If you are including this preset manually to customise the font rule\n' +
-      "configured by another preset, instead use that preset's own options to do so\n" +
-      '(such as the `font` option when using the Neutrino web/react/vue/... presets).'
-    );
+    throw new DuplicateRuleError('@neutrinojs/font-loader', ruleId);
   }
 
   neutrino.config.module

--- a/packages/font-loader/index.js
+++ b/packages/font-loader/index.js
@@ -1,11 +1,21 @@
 module.exports = (neutrino, options = {}) => {
+  const ruleId = 'font';
   const isProduction = process.env.NODE_ENV === 'production';
   const defaultOptions = {
     name: isProduction ? '[name].[hash:8].[ext]' : '[name].[ext]'
   };
 
+  if (neutrino.config.module.rules.has(ruleId)) {
+    throw new Error(
+      '@neutrinojs/font-loader has been used twice.\n' +
+      'If you are including this preset manually to customise the font rule\n' +
+      "configured by another preset, instead use that preset's own options to do so\n" +
+      '(such as the `font` option when using the Neutrino web/react/vue/... presets).'
+    );
+  }
+
   neutrino.config.module
-    .rule('font')
+    .rule(ruleId)
     .test(/\.(eot|ttf|woff|woff2)(\?v=\d+\.\d+\.\d+)?$/)
     .use('file')
       .loader(require.resolve('file-loader'))

--- a/packages/font-loader/test/middleware_test.js
+++ b/packages/font-loader/test/middleware_test.js
@@ -31,3 +31,9 @@ test('instantiates with options', t => {
 
   t.notThrows(() => api.config.toConfig());
 });
+
+test('throws when used twice', t => {
+  const api = new Neutrino();
+  api.use(mw());
+  t.throws(() => api.use(mw()), /@neutrinojs\/font-loader has been used twice/);
+});

--- a/packages/font-loader/test/middleware_test.js
+++ b/packages/font-loader/test/middleware_test.js
@@ -35,5 +35,8 @@ test('instantiates with options', t => {
 test('throws when used twice', t => {
   const api = new Neutrino();
   api.use(mw());
-  t.throws(() => api.use(mw()), /@neutrinojs\/font-loader has been used twice/);
+  t.throws(
+    () => api.use(mw()),
+    /@neutrinojs\/font-loader has been used twice with the same ruleId of 'font'/
+  );
 });

--- a/packages/html-template/index.js
+++ b/packages/html-template/index.js
@@ -1,8 +1,9 @@
 const { resolve } = require('path');
+const { ConfigurationError } = require('neutrino/errors');
 
 module.exports = (neutrino, { pluginId = 'html', ...options } = {}) => {
   if ('links' in options && !('template' in options)) {
-    throw new Error(
+    throw new ConfigurationError(
       'The default Neutrino HTML template no longer supports the "links" option. ' +
       'To set a favicon use the "favicon" option instead. For stylesheets either ' +
       'import the equivalent npm package from JS, or if using a CDN is preferred, ' +

--- a/packages/image-loader/index.js
+++ b/packages/image-loader/index.js
@@ -1,3 +1,5 @@
+const { DuplicateRuleError } = require('neutrino/errors');
+
 module.exports = (neutrino, options = {}) => {
   const ruleId = 'image';
   const isProduction = process.env.NODE_ENV === 'production';
@@ -7,12 +9,7 @@ module.exports = (neutrino, options = {}) => {
   };
 
   if (neutrino.config.module.rules.has(ruleId)) {
-    throw new Error(
-      '@neutrinojs/image-loader has been used twice.\n' +
-      'If you are including this preset manually to customise the image rule\n' +
-      "configured by another preset, instead use that preset's own options to do so\n" +
-      '(such as the `image` option when using the Neutrino web/react/vue/... presets).'
-    );
+    throw new DuplicateRuleError('@neutrinojs/image-loader', ruleId);
   }
 
   neutrino.config.module

--- a/packages/image-loader/index.js
+++ b/packages/image-loader/index.js
@@ -1,12 +1,22 @@
 module.exports = (neutrino, options = {}) => {
+  const ruleId = 'image';
   const isProduction = process.env.NODE_ENV === 'production';
   const defaultOptions = {
     limit: 8192,
     name: isProduction ? '[name].[hash:8].[ext]' : '[name].[ext]'
   };
 
+  if (neutrino.config.module.rules.has(ruleId)) {
+    throw new Error(
+      '@neutrinojs/image-loader has been used twice.\n' +
+      'If you are including this preset manually to customise the image rule\n' +
+      "configured by another preset, instead use that preset's own options to do so\n" +
+      '(such as the `image` option when using the Neutrino web/react/vue/... presets).'
+    );
+  }
+
   neutrino.config.module
-    .rule('image')
+    .rule(ruleId)
     .test(/\.(ico|png|jpg|jpeg|gif|svg|webp)(\?v=\d+\.\d+\.\d+)?$/)
     .use('url')
       .loader(require.resolve('url-loader'))

--- a/packages/image-loader/test/middleware_test.js
+++ b/packages/image-loader/test/middleware_test.js
@@ -31,3 +31,9 @@ test('instantiates with options', t => {
 
   t.notThrows(() => api.config.toConfig());
 });
+
+test('throws when used twice', t => {
+  const api = new Neutrino();
+  api.use(mw());
+  t.throws(() => api.use(mw()), /@neutrinojs\/image-loader has been used twice/);
+});

--- a/packages/image-loader/test/middleware_test.js
+++ b/packages/image-loader/test/middleware_test.js
@@ -35,5 +35,8 @@ test('instantiates with options', t => {
 test('throws when used twice', t => {
   const api = new Neutrino();
   api.use(mw());
-  t.throws(() => api.use(mw()), /@neutrinojs\/image-loader has been used twice/);
+  t.throws(
+    () => api.use(mw()),
+    /@neutrinojs\/image-loader has been used twice with the same ruleId of 'image'/
+  );
 });

--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -4,14 +4,19 @@ const clean = require('@neutrinojs/clean');
 const loaderMerge = require('@neutrinojs/loader-merge');
 const merge = require('deepmerge');
 const nodeExternals = require('webpack-node-externals');
+const { ConfigurationError } = require('neutrino/errors');
 
 module.exports = (neutrino, opts = {}) => {
   if (!opts.name) {
-    throw new Error('Missing required preset option "name". You must specify a library name when using this preset.');
+    throw new ConfigurationError(
+      'Missing required preset option "name". You must specify a library name when using this preset.'
+    );
   }
 
   if ('polyfills' in opts) {
-    throw new Error('The polyfills option has been removed, since polyfills are no longer included by default.');
+    throw new ConfigurationError(
+      'The polyfills option has been removed, since polyfills are no longer included by default.'
+    );
   }
 
   const options = merge({

--- a/packages/neutrino/Neutrino.js
+++ b/packages/neutrino/Neutrino.js
@@ -3,6 +3,7 @@ const Config = require('webpack-chain');
 const isPlainObject = require('is-plain-object');
 const merge = require('deepmerge');
 const { isAbsolute, join } = require('path');
+const { ConfigurationError } = require('./errors');
 const { source } = require('./extensions');
 
 const getRoot = ({ root }) => root;
@@ -134,7 +135,9 @@ module.exports = class Neutrino {
       });
 
     if ('node_modules' in options) {
-      throw new Error('options.node_modules has been removed. Use `neutrino.config.resolve.modules` instead.');
+      throw new ConfigurationError(
+        'options.node_modules has been removed. Use `neutrino.config.resolve.modules` instead.'
+      );
     }
 
     return options;
@@ -217,7 +220,9 @@ module.exports = class Neutrino {
       this.use(...middleware);
     } else if (isPlainObject(middleware)) {
       if ('env' in middleware) {
-        throw new Error('Using "env" in middleware has been removed. Apply middleware conditionally instead.');
+        throw new ConfigurationError(
+          'Using "env" in middleware has been removed. Apply middleware conditionally instead.'
+        );
       }
       // If middleware is an object, it could contain other middleware in
       // its "use" property. Run every item in "use" prop back through .use(),

--- a/packages/neutrino/errors.js
+++ b/packages/neutrino/errors.js
@@ -1,0 +1,21 @@
+class ConfigurationError extends Error {
+  get name() {
+    return this.constructor.name;
+  }
+}
+
+class DuplicateRuleError extends ConfigurationError {
+  constructor(middlewareName, ruleId) {
+    super(
+      `${middlewareName} has been used twice with the same ruleId of '${ruleId}', ` +
+      'which would overwrite the existing configuration. If you are including ' +
+      'this preset manually to customise rules configured by another preset, ' +
+      "instead use that preset's own options to do so."
+    );
+  }
+}
+
+module.exports = {
+  ConfigurationError,
+  DuplicateRuleError
+};

--- a/packages/neutrino/handlers.js
+++ b/packages/neutrino/handlers.js
@@ -1,6 +1,8 @@
+const { ConfigurationError } = require('./errors');
+
 const webpack = (neutrino) => {
   if (neutrino.config.entryPoints.has('vendor')) {
-    throw new Error(
+    throw new ConfigurationError(
       'Vendor chunks are now automatically generated. ' +
       'Remove the manual `vendor` entrypoint.'
     );
@@ -22,7 +24,7 @@ const webpack = (neutrino) => {
   // disable source maps in terser-webpack-plugin, then they can unset `sourceMap` rather
   // than setting it to `false`.
   if (usingSourcemap && minimizer && (minimizer.get('args')[0] || {}).sourceMap === false) {
-    throw new Error(
+    throw new ConfigurationError(
       `neutrino.config.devtool is set to '${devtool}', however terser-webpack-plugin ` +
       'has not been correctly configured to allow source maps. ' +
       'This can happen if the devtool is configured manually outside of the preset. ' +

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -8,6 +8,7 @@ const {
 } = require('path');
 const merge = require('deepmerge');
 const omit = require('lodash.omit');
+const { ConfigurationError } = require('neutrino/errors');
 
 const getOutputForEntry = entry => basename(
   format(
@@ -20,7 +21,9 @@ const getOutputForEntry = entry => basename(
 
 module.exports = (neutrino, opts = {}) => {
   if ('polyfills' in opts) {
-    throw new Error('The polyfills option has been removed, since polyfills are no longer included by default.');
+    throw new ConfigurationError(
+      'The polyfills option has been removed, since polyfills are no longer included by default.'
+    );
   }
 
   const pkg = neutrino.options.packageJson;

--- a/packages/style-loader/index.js
+++ b/packages/style-loader/index.js
@@ -1,4 +1,5 @@
 const merge = require('deepmerge');
+const { DuplicateRuleError } = require('neutrino/errors');
 
 module.exports = (neutrino, opts = {}) => {
   const modules = 'modules' in opts ? opts.modules : true;
@@ -29,12 +30,7 @@ module.exports = (neutrino, opts = {}) => {
   }, opts);
 
   if (neutrino.config.module.rules.has(options.ruleId)) {
-    throw new Error(
-      '@neutrinojs/style-loader has been used twice with the same `ruleId`.\n' +
-      'If you are including this preset manually to customise the style rules\n' +
-      "configured by another preset, instead use that preset's own options to do so\n" +
-      '(such as the `style` option when using the Neutrino web/react/vue/... presets).'
-    );
+    throw new DuplicateRuleError('@neutrinojs/style-loader', options.ruleId);
   }
 
   const rules = [options];

--- a/packages/style-loader/index.js
+++ b/packages/style-loader/index.js
@@ -28,6 +28,15 @@ module.exports = (neutrino, opts = {}) => {
     }
   }, opts);
 
+  if (neutrino.config.module.rules.has(options.ruleId)) {
+    throw new Error(
+      '@neutrinojs/style-loader has been used twice with the same `ruleId`.\n' +
+      'If you are including this preset manually to customise the style rules\n' +
+      "configured by another preset, instead use that preset's own options to do so\n" +
+      '(such as the `style` option when using the Neutrino web/react/vue/... presets).'
+    );
+  }
+
   const rules = [options];
 
   if (options.modules) {

--- a/packages/style-loader/test/middleware_test.js
+++ b/packages/style-loader/test/middleware_test.js
@@ -60,3 +60,9 @@ test('respects disabling of CSS modules', t => {
     t.falsy(use.options && use.options.css && use.options.css.modules);
   });
 });
+
+test('throws when used twice', t => {
+  const api = new Neutrino();
+  api.use(mw());
+  t.throws(() => api.use(mw()), /@neutrinojs\/style-loader has been used twice/);
+});

--- a/packages/style-loader/test/middleware_test.js
+++ b/packages/style-loader/test/middleware_test.js
@@ -64,5 +64,8 @@ test('respects disabling of CSS modules', t => {
 test('throws when used twice', t => {
   const api = new Neutrino();
   api.use(mw());
-  t.throws(() => api.use(mw()), /@neutrinojs\/style-loader has been used twice/);
+  t.throws(
+    () => api.use(mw()),
+    /@neutrinojs\/style-loader has been used twice with the same ruleId of 'style'/
+  );
 });

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -11,6 +11,15 @@ const { resolve } = require('url');
 const merge = require('deepmerge');
 
 module.exports = (neutrino, opts = {}) => {
+  if (neutrino.config.module.rules.has('compile')) {
+    throw new Error(
+      '@neutrinojs/web is being used when a `compile` rule already exists,\n' +
+      'which would cause the existing configuration to be overwritten.\n' +
+      'If you are including this preset manually to customise options configured\n' +
+      "by another preset, instead use that preset's own options to do so."
+    );
+  }
+
   const isProduction = process.env.NODE_ENV === 'production';
   const publicPath = opts.publicPath || './';
   const options = merge({

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -9,14 +9,15 @@ const loaderMerge = require('@neutrinojs/loader-merge');
 const devServer = require('@neutrinojs/dev-server');
 const { resolve } = require('url');
 const merge = require('deepmerge');
+const { ConfigurationError } = require('neutrino/errors');
 
 module.exports = (neutrino, opts = {}) => {
   if (neutrino.config.module.rules.has('compile')) {
-    throw new Error(
-      '@neutrinojs/web is being used when a `compile` rule already exists,\n' +
-      'which would cause the existing configuration to be overwritten.\n' +
-      'If you are including this preset manually to customise options configured\n' +
-      "by another preset, instead use that preset's own options to do so."
+    throw new ConfigurationError(
+      '@neutrinojs/web is being used when a `compile` rule already exists, ' +
+      'which would overwrite the existing configuration. If you are including ' +
+      'this preset manually to customise rules configured by another preset, ' +
+      "instead use that preset's own options to do so."
     );
   }
 
@@ -54,23 +55,31 @@ module.exports = (neutrino, opts = {}) => {
   }, opts);
 
   if ('babel' in options.minify) {
-    throw new Error('The minify.babel option has been removed. See the web preset docs for how to customise source minification.');
+    throw new ConfigurationError(
+      'The minify.babel option has been removed. See the web preset docs for how to customise source minification.'
+    );
   }
 
   if ('image' in options.minify) {
-    throw new Error('The minify.image option has been removed. See: https://github.com/neutrinojs/neutrino/issues/1104');
+    throw new ConfigurationError(
+      'The minify.image option has been removed. See: https://github.com/neutrinojs/neutrino/issues/1104'
+    );
   }
 
   if ('style' in options.minify) {
-    throw new Error('The minify.style option has been removed. To enable style minification use the @neutrinojs/style-minify preset.');
+    throw new ConfigurationError(
+      'The minify.style option has been removed. To enable style minification use the @neutrinojs/style-minify preset.'
+    );
   }
 
   if ('polyfills' in options) {
-    throw new Error('The polyfills option has been removed, since polyfills are no longer included by default.');
+    throw new ConfigurationError(
+      'The polyfills option has been removed, since polyfills are no longer included by default.'
+    );
   }
 
   if ('hotEntries' in options) {
-    throw new Error(
+    throw new ConfigurationError(
       'The hotEntries option has been removed. See the "neutrino.options.mains" ' +
       'docs for how to add custom hot entries to your bundle without importing.'
     );

--- a/packages/web/test/web_test.js
+++ b/packages/web/test/web_test.js
@@ -246,7 +246,10 @@ test('supports multiple mains with custom html-webpack-plugin options', t => {
 test('throws when used twice', t => {
   const api = new Neutrino();
   api.use(mw());
-  t.throws(() => api.use(mw()), /a `compile` rule already exists/);
+  t.throws(
+    () => api.use(mw()),
+    /@neutrinojs\/web is being used when a `compile` rule already exists/
+  );
 });
 
 test('throws when minify.babel defined', t => {

--- a/packages/web/test/web_test.js
+++ b/packages/web/test/web_test.js
@@ -243,6 +243,12 @@ test('supports multiple mains with custom html-webpack-plugin options', t => {
   }]);
 });
 
+test('throws when used twice', t => {
+  const api = new Neutrino();
+  api.use(mw());
+  t.throws(() => api.use(mw()), /a `compile` rule already exists/);
+});
+
 test('throws when minify.babel defined', t => {
   const api = new Neutrino();
   t.throws(


### PR DESCRIPTION
To try and prevent the confusion caused when users do things like:
* using `@neutrinojs/react` followed by `@neutrinojs/web`, which clobbers the React parts of the config:
  https://github.com/neutrinojs/neutrino/issues/1129#issuecomment-428169383
* using `@neutrinojs/react` followed by `@neutrinojs/style`, which causes incorrect `extract` and `hot` configuration:
  https://github.com/neutrinojs/neutrino/issues/1129#issuecomment-423947761
  https://github.com/neutrinojs/neutrino/issues/755#issuecomment-374913991
  https://github.com/neutrinojs/neutrino/issues/803#issuecomment-388445048
  https://github.com/neutrinojs/neutrino/issues/869#issue-322397071