### PR TITLE
Clean up the display of errors during middleware instantiation

### DIFF
--- a/packages/neutrino/index.js
+++ b/packages/neutrino/index.js
@@ -32,7 +32,13 @@ module.exports = (middleware = {}) => {
   neutrino.register('inspect', inspect);
 
   if (use) {
-    neutrino.use(use);
+    try {
+      neutrino.use(use);
+    } catch (err) {
+      console.error('\nAn error occurred when loading the Neutrino configuration.\n');
+      console.error(err);
+      process.exit(1);
+    }
   }
 
   const adapter = {


### PR DESCRIPTION
Before:

```
$ webpack --mode production
/app/node_modules/webpack-cli/bin/cli.js:244
                                throw err;
                                ^

Error: Using "env" in middleware has been removed. Apply middleware conditionally instead.
    at Neutrino.use (/app/node_modules/neutrino/Neutrino.js:220:15)
    at module.exports (/app/node_modules/neutrino/index.js:35:14)
    at module.exports (/app/webpack.config.js:9:10)
    ...
```

After:

```
$ webpack --mode production

An error occurred when loading the Neutrino configuration.

Error: Using "env" in middleware has been removed. Apply middleware conditionally instead.
    at Neutrino.use (/app/node_modules/neutrino/Neutrino.js:220:15)
    at module.exports (/app/node_modules/neutrino/index.js:36:16)
    at module.exports (/app/webpack.config.js:9:10)
    ...
```