### PR TITLE
jest: Use babel-jest instead of a custom implementation

### DIFF
--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -22,14 +22,11 @@
     "yarn": ">=1.2.1"
   },
   "dependencies": {
-    "@babel/core": "^7.1.2",
-    "@babel/plugin-transform-modules-commonjs": "^7.1.0",
-    "@neutrinojs/compile-loader": "9.0.0-0",
     "@neutrinojs/loader-merge": "9.0.0-0",
-    "babel-plugin-jest-hoist": "^23.2.0",
+    "babel-core": "^7.0.0-bridge",
+    "babel-jest": "^23.6.0",
     "deepmerge": "^1.5.2",
-    "eslint-plugin-jest": "^21.25.0",
-    "lodash.omit": "^4.5.0"
+    "eslint-plugin-jest": "^21.25.0"
   },
   "peerDependencies": {
     "jest": "^23.0.0",

--- a/packages/jest/src/transformer.js
+++ b/packages/jest/src/transformer.js
@@ -1,13 +1,5 @@
-const { transform } = require('@babel/core');
+const { createTransformer } = require('babel-jest');
 
-module.exports = {
-  // This is inspired by:
-  // https://github.com/facebook/jest/blob/v22.4.2/packages/babel-jest/src/index.js#L105-L147
-  // And is required due to:
-  // https://github.com/facebook/jest/issues/1468
-  // TODO: See if it would be easier to wrap the higher-level babel-jest instead.
-  process(src, filename, config) {
-    // Babel 7 returns null if the file was ignored.
-    return transform(src, { filename, ...config.globals.BABEL_OPTIONS }) || src;
-  }
-};
+const babelOptions = JSON.parse(process.env.JEST_BABEL_OPTIONS);
+
+module.exports = createTransformer(babelOptions);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1536,6 +1536,11 @@ babel-core@^6.0.0, babel-core@^6.26.0:
     slash "^1.0.0"
     source-map "^0.5.7"
 
+babel-core@^7.0.0-bridge:
+  version "7.0.0-bridge.0"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
+  integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
+
 babel-eslint@^10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.1.tgz#919681dc099614cd7d31d45c8908695092a1faed"


### PR DESCRIPTION
We were previously just reimplementing parts of it, and not using the latest recommended Babel settings (such as still setting `retainLines: true` when sourcemaps are supported natively).

There isn't currently a way to set the babel-jest `createTransformer()` options via Jest configuration/globals, so we instead have to resort to using an environment variable. This has the limitation of only supporting Babel options that are serializable (virtually all commonly used configuration options are), with any others being silently omitted. However this was already the case when using `globals` anyway.

See:
https://github.com/facebook/jest/blob/v23.6.0/packages/babel-jest/README.md
https://github.com/facebook/jest/blob/v23.6.0/packages/babel-jest/src/index.js

Fixes #851.