### PR TITLE
eslint: Set the eslint-plugin-react react version to latest

### DIFF
--- a/packages/airbnb/README.md
+++ b/packages/airbnb/README.md
@@ -154,6 +154,9 @@ If you wish to customize what is included, excluded, or any ESLint options, you 
 middleware and this will be merged with our internal defaults for this preset. Use an array pair instead of a string
 to supply these options.
 
+By default the preset configures `eslint-plugin-react` to target the latest version of React.
+If using an older version, you must explicitly pass it as in the example below.
+
 _Example: Extend from a custom configuration (it will be applied after Airbnb),
 turn off semicolons from being required, and set a specific React version._
 

--- a/packages/airbnb/index.js
+++ b/packages/airbnb/index.js
@@ -25,6 +25,13 @@ module.exports = (neutrino, { eslint = {}, ...opts } = {}) => {
             'babel/object-curly-spacing': airbnbBaseStyle['object-curly-spacing'],
             'babel/semi': airbnbBaseStyle.semi,
             'babel/no-unused-expressions': airbnbBaseBestPractices['no-unused-expressions']
+          },
+          settings: {
+            react: {
+              // https://github.com/yannickcr/eslint-plugin-react#configuration
+              // This is undocumented, but equivalent to "latest version".
+              version: '999.999.999'
+            }
           }
         },
         eslint.baseConfig || {}

--- a/packages/airbnb/test/airbnb_test.js
+++ b/packages/airbnb/test/airbnb_test.js
@@ -113,7 +113,11 @@ test('sets defaults when no options passed', t => {
         'object-curly-spacing': 'off',
         semi: 'off'
       },
-      settings: {}
+      settings: {
+        react: {
+          version: '999.999.999'
+        }
+      }
     },
     cache: true,
     cwd: api.options.root,

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -50,7 +50,14 @@ module.exports = (neutrino, opts = {}) => {
         ? lintOptions
         : merge(lintOptions, {
             baseConfig: {
-              plugins: ['react']
+              plugins: ['react'],
+              settings: {
+                react: {
+                  // https://github.com/yannickcr/eslint-plugin-react#configuration
+                  // This is undocumented, but equivalent to "latest version".
+                  version: '999.999.999'
+                }
+              }
             }
           })
     );

--- a/packages/react/test/react_test.js
+++ b/packages/react/test/react_test.js
@@ -70,6 +70,11 @@ test('updates lint config by default', t => {
     es6: true
   });
   t.deepEqual(options.baseConfig.plugins, ['babel', 'react']);
+  t.deepEqual(options.baseConfig.settings, {
+    react: {
+      version: '999.999.999'
+    }
+  });
 });
 
 test('does not update lint config if useEslintrc true', t => {

--- a/packages/standardjs/README.md
+++ b/packages/standardjs/README.md
@@ -154,6 +154,9 @@ If you wish to customize what is included, excluded, or any ESLint options, you 
 middleware and this will be merged with our internal defaults for this preset. Use an array pair instead of a string
 to supply these options.
 
+By default the preset configures `eslint-plugin-react` to target the latest version of React.
+If using an older version, you must explicitly pass it as in the example below.
+
 _Example: Extend from a custom configuration (it will be applied after StandardJS),
 turn on semicolons as being required, and set a specific React version._
 

--- a/packages/standardjs/index.js
+++ b/packages/standardjs/index.js
@@ -34,6 +34,13 @@ module.exports = (neutrino, { eslint = {}, ...opts } = {}) => {
             'babel/object-curly-spacing': standardRules['object-curly-spacing'] || 'off',
             'babel/semi': standardRules.semi,
             'babel/no-unused-expressions': standardRules['no-unused-expressions']
+          },
+          settings: {
+            react: {
+              // https://github.com/yannickcr/eslint-plugin-react#configuration
+              // This is undocumented, but equivalent to "latest version".
+              version: '999.999.999'
+            }
           }
         },
         eslint.baseConfig || {}

--- a/packages/standardjs/test/standardjs_test.js
+++ b/packages/standardjs/test/standardjs_test.js
@@ -113,7 +113,11 @@ test('sets defaults when no options passed', t => {
         'object-curly-spacing': 'off',
         semi: 'off'
       },
-      settings: {}
+      settings: {
+        react: {
+          version: '999.999.999'
+        }
+      }
     },
     cache: true,
     cwd: api.options.root,


### PR DESCRIPTION
Several of the `eslint-plugin-react` rules use the specified React version to determine what warnings/errors to show (for example only showing deprecation warnings for certain features if using a newer version of React). Not setting a version, or setting one that's older than the version of React being used means that valid warnings/errors may not actually be shown.

Whilst `eslint-plugin-react` helpfully outputs a warning if an explicit React version has not been specified, several popular presets (such as `eslint-config-airbnb` and `eslint-config-standard-react`) set a default version of `16.0`, which results in many rules being disabled.

As such, we're using the trick used by CRA, of setting the version to `999.999.999`, which ends up being interpreted as "latest version" by `eslint-plugin-react`'s rules.

Fixes #1155.