### PR TITLE
web: Default output.publicPath to '/'

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -177,6 +177,10 @@ to RHL v4 while installing it into your project also.
 - **BREAKING CHANGE** `@neutrinojs/web`, `@neutrinojs/node`, and their dependent presets no longer configure
 defaults for copying static files at build time [#814](https://github.com/neutrinojs/neutrino/pull/814).
 Use the `@neutrinojs/copy` middleware to configure this for v9.
+- **BREAKING CHANGE** `@neutrinojs/web` and dependent presets now default `output.publicPath` to `'/'`,
+which means that apps not served from the root of a domain (such as those hosted on GitHub pages) will
+need to explicitly set their `publicPath` [#1185](https://github.com/neutrinojs/neutrino/pull/1185).
+See the [deployment path documentation](./packages/web.md#deployment-path).
 - **BREAKING CHANGE** `@neutrinojs/dev-server` (used by `@neutrinojs/web`) no longer sets
 [contentBase](https://webpack.js.org/configuration/dev-server/#devserver-contentbase)
 by default, meaning that in development any files that are not part of the webpack build need to be

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -175,12 +175,20 @@ You can either serve or deploy the contents of this `build` directory as a stati
 If you wish to copy files to the build directory that are not imported from application code,
 use the [@neutrinojs/copy](https://neutrinojs.org/packages/copy/) preset alongside this one.
 
-## Paths
+## Deployment Path
 
-The `@neutrinojs/preact` preset loads assets relative to the path of your application by setting webpack's
-[`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) to `''`. If you wish to load
-assets instead from a CDN, or if you wish to change to an absolute path for your application, customize your build to
-override `output.publicPath`. See the [Customizing](#customizing) section below.
+By default `@neutrinojs/preact` assumes that your application will be deployed at the root of a
+domain (eg: `https://www.my-app.com/`), and so sets webpack's
+[`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) to `'/'`,
+which means assets will be loaded from the site root using absolute paths.
+
+If your app is instead deployed within a subdirectory, you will need to adjust the `publicPath`
+[preset option](#preset-options). For example if your app is hosted at
+`https://my-username.github.io/my-app/`, you will need to set `publicPath` to `'/my-app/'`.
+
+Alternatively, if you would like your app to be able to be served from any location, and are
+not using the HTML5 pushState history API or client-side routing, then you can set `publicPath`
+to the empty string, which will cause relative asset paths to be used instead.
 
 ## Preset options
 
@@ -199,6 +207,10 @@ module.exports = {
 
       // Example: disable Hot Module Replacement
       hot: false,
+
+      // Controls webpack's `output.publicPath` setting.
+      // See the "Deployment Path" section above for more info.
+      publicPath: '/',
 
       // Example: change the page title
       html: {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -160,12 +160,20 @@ You can either serve or deploy the contents of this `build` directory as a stati
 If you wish to copy files to the build directory that are not imported from application code,
 use the [@neutrinojs/copy](https://neutrinojs.org/packages/copy/) preset alongside this one.
 
-## Paths
+## Deployment Path
 
-The `@neutrinojs/web` preset loads assets relative to the path of your application by setting webpack's
-[`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) to `''`. If you wish to load
-assets instead from a CDN, or if you wish to change to an absolute path for your application, customize your build to
-override `output.publicPath`. See the [Customizing](#customizing) section below.
+By default `@neutrinojs/react` assumes that your application will be deployed at the root of a
+domain (eg: `https://www.my-app.com/`), and so sets webpack's
+[`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) to `'/'`,
+which means assets will be loaded from the site root using absolute paths.
+
+If your app is instead deployed within a subdirectory, you will need to adjust the `publicPath`
+[preset option](#preset-options). For example if your app is hosted at
+`https://my-username.github.io/my-app/`, you will need to set `publicPath` to `'/my-app/'`.
+
+Alternatively, if you would like your app to be able to be served from any location, and are
+not using the HTML5 pushState history API or client-side routing, then you can set `publicPath`
+to the empty string, which will cause relative asset paths to be used instead.
 
 ## Preset options
 
@@ -184,6 +192,10 @@ module.exports = {
 
       // Example: disable Hot Module Replacement
       hot: false,
+
+      // Controls webpack's `output.publicPath` setting.
+      // See the "Deployment Path" section above for more info.
+      publicPath: '/',
 
       // Example: change the page title
       html: {

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -179,12 +179,20 @@ You can either serve or deploy the contents of this `build` directory as a stati
 If you wish to copy files to the build directory that are not imported from application code,
 use the [@neutrinojs/copy](https://neutrinojs.org/packages/copy/) preset alongside this one.
 
-## Paths
+## Deployment Path
 
-The `@neutrinojs/web` preset loads assets relative to the path of your application by setting webpack's
-[`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) to `''`. If you wish to load
-assets instead from a CDN, or if you wish to change to an absolute path for your application, customize your build to
-override `output.publicPath`. See the [Customizing](#customizing) section below.
+By default `@neutrinojs/vue` assumes that your application will be deployed at the root of a
+domain (eg: `https://www.my-app.com/`), and so sets webpack's
+[`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) to `'/'`,
+which means assets will be loaded from the site root using absolute paths.
+
+If your app is instead deployed within a subdirectory, you will need to adjust the `publicPath`
+[preset option](#preset-options). For example if your app is hosted at
+`https://my-username.github.io/my-app/`, you will need to set `publicPath` to `'/my-app/'`.
+
+Alternatively, if you would like your app to be able to be served from any location, and are
+not using the HTML5 pushState history API or client-side routing, then you can set `publicPath`
+to the empty string, which will cause relative asset paths to be used instead.
 
 ## Preset options
 
@@ -203,6 +211,10 @@ module.exports = {
 
       // Example: disable Hot Module Replacement
       hot: false,
+
+      // Controls webpack's `output.publicPath` setting.
+      // See the "Deployment Path" section above for more info.
+      publicPath: '/',
 
       // Example: change the page title
       html: {

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -155,12 +155,20 @@ You can either serve or deploy the contents of this `build` directory as a stati
 If you wish to copy files to the build directory that are not imported from application code,
 use the [@neutrinojs/copy](https://neutrinojs.org/packages/copy/) preset alongside this one.
 
-## Paths
+## Deployment Path
 
-The `@neutrinojs/web` preset loads assets relative to the path of your application by setting webpack's
-[`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) to `''`. If you wish to load
-assets instead from a CDN, or if you wish to change to an absolute path for your application, customize your build to
-override `output.publicPath`. See the [Customizing](#customizing) section below.
+By default `@neutrinojs/web` assumes that your application will be deployed at the root of a
+domain (eg: `https://www.my-app.com/`), and so sets webpack's
+[`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) to `'/'`,
+which means assets will be loaded from the site root using absolute paths.
+
+If your app is instead deployed within a subdirectory, you will need to adjust the `publicPath`
+[preset option](#preset-options). For example if your app is hosted at
+`https://my-username.github.io/my-app/`, you will need to set `publicPath` to `'/my-app/'`.
+
+Alternatively, if you would like your app to be able to be served from any location, and are
+not using the HTML5 pushState history API or client-side routing, then you can set `publicPath`
+to the empty string, which will cause relative asset paths to be used instead.
 
 ## Preset options
 
@@ -180,9 +188,9 @@ module.exports = {
       // Enables Hot Module Replacement. Set to false to disable
       hot: true,
 
-      // Sets webpack's `output.publicPath` setting, which is useful if you
-      // want to serve assets from a non-root location (e.g. `/assets/`).
-      publicPath: '',
+      // Controls webpack's `output.publicPath` setting.
+      // See the "Deployment Path" section above for more info.
+      publicPath: '/',
 
       // Change options for @neutrinojs/style-loader
       style: {

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -21,7 +21,10 @@ module.exports = (neutrino, opts = {}) => {
 
   const isProduction = process.env.NODE_ENV === 'production';
   const options = merge({
-    publicPath: '',
+    // Default to an absolute public path, so pushState API sites work.
+    // Apps deployed to a subdirectory will need to override this.
+    // https://webpack.js.org/configuration/output/#output-publicpath
+    publicPath: '/',
     env: false,
     hot: true,
     html: {},

--- a/packages/web/test/web_test.js
+++ b/packages/web/test/web_test.js
@@ -44,7 +44,7 @@ test('valid preset production', t => {
   t.true(config.optimization.minimize);
   t.is(config.optimization.minimizer.length, 1);
   t.false(config.optimization.splitChunks.name);
-  t.is(config.output.publicPath, '');
+  t.is(config.output.publicPath, '/');
   t.is(config.devtool, undefined);
   t.is(config.devServer, undefined);
 
@@ -63,7 +63,7 @@ test('valid preset development', t => {
   t.deepEqual(config.resolve.extensions, expectedExtensions);
   t.is(config.optimization.runtimeChunk, 'single');
   t.is(config.optimization.splitChunks.chunks, 'all');
-  t.is(config.output.publicPath, '');
+  t.is(config.output.publicPath, '/');
   t.deepEqual(config.stats, {
     children: false,
     entrypoints: false,
@@ -102,7 +102,7 @@ test('valid preset test', t => {
   t.deepEqual(config.resolve.extensions, expectedExtensions);
   t.is(config.optimization.runtimeChunk, 'single');
   t.is(config.optimization.splitChunks.chunks, 'all');
-  t.is(config.output.publicPath, '');
+  t.is(config.output.publicPath, '/');
   t.deepEqual(config.stats, {
     children: false,
     entrypoints: false,


### PR DESCRIPTION
Since otherwise apps that use the HTML 5 pushState history API won't work when deployed, even with the necessary server rewrite rules configured.

Apps that are deployed from a non-domain-root location (such as those hosted on GitHub pages) will now need to explicitly set `publicPath` themselves, however this is the case with CRA and vue-cli too.

Fixes #1171.