### PR TITLE
Travis: Test against Node 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,7 @@ before_install:
 - curl -sSfL https://yarnpkg.com/install.sh | bash
 - export PATH="$HOME/.yarn/bin:$PATH"
 install:
-# Remove --ignore-engines when this fixed:
-# https://github.com/anodynos/upath/issues/14
-- yarn install --frozen-lockfile --ignore-engines
+- yarn --frozen-lockfile
 script:
 - yarn validate:eslintrc
 - yarn lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,10 @@
-# Use the fully virtualised infra not for sudo, but since their container
-# infra's 4GB of RAM is not sufficient to prevent yarn bootstrap OOMs:
-# https://github.com/guigrpa/oao/issues/51
-# https://docs.travis-ci.com/user/reference/overview/#Virtualization-environments
-sudo: required
-dist: trusty
+dist: xenial
 language: node_js
 cache: yarn
 node_js:
 - '8'
 - '10'
+- '11'
 before_install:
 # Use newer yarn than that pre-installed in the Travis image.
 - curl -sSfL https://yarnpkg.com/install.sh | bash


### PR DESCRIPTION
Also switch to Travis' Xenial image, and remove the redundant `sudo` option, since the GCE infra is now the default:
https://changelog.travis-ci.com/linux-builds-run-on-vms-by-default-77106

No changes are required to the `engines` declarations or READMEs, since they already used `"^8.10 || >=10"` and "^8.10 or 10+" respectively.