### PR TITLE
react: Remove propTypes in production

### DIFF
--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -7,7 +7,7 @@ module.exports = (neutrino, opts = {}) => {
     hot: true,
     babel: {}
   }, opts);
-  let reactHotLoader;
+  let reactHotLoader = false;
 
   try {
     // Attempt to load react-hot-loader from the user's installation.
@@ -17,17 +17,19 @@ module.exports = (neutrino, opts = {}) => {
   Object.assign(options, {
     babel: compileLoader.merge({
       plugins: [
-        ...(
-          // The plugin is enabled in production too since it removes the `hot(module)(...)`
-          // wrapper, allowing webpack to use its concatenate modules optimization.
-          options.hot && reactHotLoader
-            ? [reactHotLoader]
-            : []
-        ),
+        // The RHL plugin is enabled in production too since it removes the `hot(module)(...)`
+        // wrapper, allowing webpack to use its concatenate modules optimization.
+        options.hot && reactHotLoader,
+        process.env.NODE_ENV === 'production' && [
+          require.resolve('babel-plugin-transform-react-remove-prop-types'),
+          {
+            removeImport: true
+          }
+        ],
         // Using loose for the reasons here:
         // https://github.com/facebook/create-react-app/issues/4263
         [require.resolve('@babel/plugin-proposal-class-properties'), { loose: true }]
-      ],
+      ].filter(Boolean),
       presets: [
         [
           require.resolve('@babel/preset-react'),

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,6 +29,7 @@
     "@babel/preset-react": "^7.0.0",
     "@neutrinojs/compile-loader": "9.0.0-0",
     "@neutrinojs/web": "9.0.0-0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.20",
     "deepmerge": "^1.5.2",
     "eslint-plugin-react": "^7.11.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1644,6 +1644,11 @@ babel-plugin-syntax-object-rest-spread@^6.13.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
   integrity sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=
 
+babel-plugin-transform-react-remove-prop-types@^0.4.20:
+  version "0.4.20"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.20.tgz#688bdea1e27ea0023775dea817fa2d3f8df8802b"
+  integrity sha512-bWQ8e7LsgdFpyHU/RabjDAjVhL7KLAJXEt0nb0LANFje8YAGA8RlZv88a72aCswOxELWULkYuJqfFoKgs58Tng==
+
 babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"


### PR DESCRIPTION
propTypes allow for additional runtime checks in development, but are unused in production (aside for buggy code). CRA uses this Babel plugin to remove them in production to reduce the bundle size, so it should be safe for us to do so too.

See:
https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types
https://github.com/facebook/create-react-app/blob/v2.1.1/packages/babel-preset-react-app/create.js#L161-L167