### PR TITLE
eslint: Downgrade linter errors to warnings in development

### DIFF
--- a/packages/airbnb-base/test/airbnb_test.js
+++ b/packages/airbnb-base/test/airbnb_test.js
@@ -117,6 +117,7 @@ test('sets defaults when no options passed', t => {
     },
     cache: true,
     cwd: api.options.root,
+    emitWarning: false,
     failOnError: true,
     formatter: require.resolve('eslint/lib/formatters/codeframe'),
     useEslintrc: false
@@ -216,6 +217,7 @@ test('merges options with defaults', t => {
     },
     cache: true,
     cwd: api.options.root,
+    emitWarning: false,
     failOnError: true,
     formatter: require.resolve('eslint/lib/formatters/codeframe'),
     reportUnusedDisableDirectives: true,

--- a/packages/airbnb/test/airbnb_test.js
+++ b/packages/airbnb/test/airbnb_test.js
@@ -121,6 +121,7 @@ test('sets defaults when no options passed', t => {
     },
     cache: true,
     cwd: api.options.root,
+    emitWarning: false,
     failOnError: true,
     formatter: require.resolve('eslint/lib/formatters/codeframe'),
     useEslintrc: false
@@ -220,6 +221,7 @@ test('merges options with defaults', t => {
     },
     cache: true,
     cwd: api.options.root,
+    emitWarning: false,
     failOnError: true,
     formatter: require.resolve('eslint/lib/formatters/codeframe'),
     reportUnusedDisableDirectives: true,

--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -51,7 +51,13 @@ neutrino.use(eslint, {
     // https://github.com/webpack-contrib/eslint-loader#options
     // https://eslint.org/docs/developer-guide/nodejs-api#cliengine
     cache: true,
-    // Make errors fatal not just for 'production' but also 'test'.
+    // Downgrade errors to warnings when in development, to reduce the noise in
+    // the webpack-dev-server overlay (which defaults to showing errors only),
+    // and to also ensure hot reloading isn't prevented.
+    emitWarning: process.env.NODE_ENV === 'development',
+    // Make errors fatal for 'production' and 'test'.
+    // However note that even when `false` webpack still fails the build:
+    // https://github.com/webpack-contrib/eslint-loader/issues/257
     failOnError: process.env.NODE_ENV !== 'development',
     cwd: neutrino.options.root,
     useEslintrc: false,

--- a/packages/eslint/index.js
+++ b/packages/eslint/index.js
@@ -113,7 +113,13 @@ module.exports = (neutrino, { test, include, exclude, eslint = {} } = {}) => {
     // https://eslint.org/docs/developer-guide/nodejs-api#cliengine
     cache: true,
     cwd: neutrino.options.root,
-    // Make errors fatal not just for 'production' but also 'test'.
+    // Downgrade errors to warnings when in development, to reduce the noise in
+    // the webpack-dev-server overlay (which defaults to showing errors only),
+    // and to also ensure hot reloading isn't prevented.
+    emitWarning: process.env.NODE_ENV === 'development',
+    // Make errors fatal for 'production' and 'test'.
+    // However note that even when `false` webpack still fails the build:
+    // https://github.com/webpack-contrib/eslint-loader/issues/257
     failOnError: process.env.NODE_ENV !== 'development',
     // Can be the name of a built-in ESLint formatter or the module/path of an external one.
     formatter: 'codeframe',

--- a/packages/eslint/test/middleware_test.js
+++ b/packages/eslint/test/middleware_test.js
@@ -142,6 +142,7 @@ test('sets defaults when no options passed', t => {
     },
     cache: true,
     cwd: api.options.root,
+    emitWarning: false,
     failOnError: true,
     formatter: require.resolve('eslint/lib/formatters/codeframe'),
     useEslintrc: false
@@ -264,6 +265,7 @@ test('merges options with defaults', t => {
     },
     cache: true,
     cwd: api.options.root,
+    emitWarning: false,
     envs: ['jest'],
     failOnError: true,
     formatter: require.resolve('eslint/lib/formatters/codeframe'),
@@ -336,6 +338,7 @@ test('sets only loader-specific defaults if useEslintrc true', t => {
     baseConfig: {},
     cache: true,
     cwd: api.options.root,
+    emitWarning: false,
     failOnError: true,
     formatter: require.resolve('eslint/lib/formatters/codeframe'),
     useEslintrc: true

--- a/packages/standardjs/test/standardjs_test.js
+++ b/packages/standardjs/test/standardjs_test.js
@@ -121,6 +121,7 @@ test('sets defaults when no options passed', t => {
     },
     cache: true,
     cwd: api.options.root,
+    emitWarning: false,
     failOnError: true,
     formatter: require.resolve('eslint/lib/formatters/codeframe'),
     useEslintrc: false
@@ -216,6 +217,7 @@ test('merges options with defaults', t => {
     },
     cache: true,
     cwd: api.options.root,
+    emitWarning: false,
     failOnError: true,
     formatter: require.resolve('eslint/lib/formatters/codeframe'),
     reportUnusedDisableDirectives: true,


### PR DESCRIPTION
To reduce the noise in the webpack-dev-server overlay (which defaults to showing errors only and is going to be enabled soon in #1131), and to also ensure hot reloading isn't prevented.

See:
https://github.com/webpack-contrib/eslint-loader#options