### PR TITLE
dev-server: Enable in-page overlay for display of errors

### DIFF
--- a/packages/dev-server/index.js
+++ b/packages/dev-server/index.js
@@ -4,6 +4,8 @@ module.exports = (neutrino, options = {}) => {
     hot: true,
     // Redirect 404s to index.html, so that apps that use the HTML 5 History API work.
     historyApiFallback: true,
+    // Display any webpack compile errors (but not warnings) on an in-page overlay.
+    overlay: true,
     // Only display compile duration and errors/warnings, to reduce noise when rebuilding.
     stats: {
       all: false,

--- a/packages/web/test/web_test.js
+++ b/packages/web/test/web_test.js
@@ -78,6 +78,7 @@ test('valid preset development', t => {
   t.deepEqual(config.devServer, {
     historyApiFallback: true,
     hot: true,
+    overlay: true,
     port: 5000,
     stats: {
       all: false,


### PR DESCRIPTION
See:
https://webpack.js.org/configuration/dev-server/#devserver-overlay

Note this change 'relies' on #1216, in that without that change all linter errors would be displayed in the overlay too, which is likely too noisy (given that many rules are for stylistic issues that should not block viewing the dev-server page output).

Fixes #1131.