### PR TITLE
mocha: Use correct function for merging lint configuration

### DIFF
--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -24,6 +24,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.1.0",
     "@babel/register": "^7.0.0",
     "babel-merge": "^2.0.1",
+    "deepmerge": "^1.5.2",
     "lodash.omit": "^4.5.0"
   },
   "peerDependencies": {

--- a/packages/mocha/src/index.js
+++ b/packages/mocha/src/index.js
@@ -1,4 +1,5 @@
-const merge = require('babel-merge');
+const babelMerge = require('babel-merge');
+const merge = require('deepmerge');
 const omit = require('lodash.omit');
 
 module.exports = neutrino => {
@@ -23,7 +24,7 @@ module.exports = neutrino => {
       ? neutrino.config.module.rule('compile').use('babel').get('options')
       : {};
     const options = omit(
-      merge(
+      babelMerge(
         baseOptions,
         {
           extensions: neutrino.options.extensions.map(ext => `.${ext}`),


### PR DESCRIPTION
The refactor in #1182 inadvertently used babel-merge's `merge()` to merge ESLint configuration in this preset rather than deepmerge, since the existing `merge` import was not the same as in other presets from which the lint rule merging block was copied.

In a later PR I think we should stop exporting a merge function from `@neutrinojs/compile-loader` named `merge`, to avoid the reduce the chance of this kind of naming conflict.

Fixes:
https://github.com/taskcluster/taskcluster-web-server/pull/59#issuecomment-440801799