### PR TITLE
compile-loader: Remove babel-merge export

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -297,6 +297,10 @@ what webpack has configured by default [#1080](https://github.com/neutrinojs/neu
 dependent middleware [#951](https://github.com/neutrinojs/neutrino/pull/951).
 - **BREAKING CHANGE** TypeScript extensions are no longer set by default in `neutrino.options.extensions`, and the
 `vue` extension is only added when used with `@neutrinojs/vue`.
+- **BREAKING CHANGE** `@neutrinojs/compile-loader` no longer exports a `merge` function
+[#1220](https://github.com/neutrinojs/neutrino/pull/1220). See the documentation on
+[merging babel configuration](./packages/compile-loader.md#merging-babel-configuration)
+for how to use the [babel-merge](https://www.npmjs.com/package/babel-merge) package directly instead.
 - **BREAKING CHANGE** Various dependencies have been updated which may bring their own breaking changes. Please
 check and test your project to ensure proper functionality.
 - ESLint caching is now enabled by default for new projects, so it is recommended to specify `.eslintcache` as being

--- a/packages/compile-loader/README.md
+++ b/packages/compile-loader/README.md
@@ -36,9 +36,9 @@ and plug it into Neutrino:
 ```js
 // Using function middleware format
 
-const compile = require('@neutrinojs/compile-loader');
+const compileLoader = require('@neutrinojs/compile-loader');
 
-neutrino.use(compile, {
+neutrino.use(compileLoader, {
   test: neutrino.regexFromExtensions(),
   include: [],
   exclude: [],
@@ -76,13 +76,13 @@ this to set properties such as `presets`, `plugins`, and `env`.
 
 ## Merging Babel Configuration
 
-This package also exposes a function for merging Babel configurations. This comes from
-the [babel-merge](https://www.npmjs.com/package/babel-merge) package.
+To correctly merge Babel configurations use the
+[babel-merge](https://www.npmjs.com/package/babel-merge) package.
 
 ```js
-const { merge } = require('@neutrinojs/compile-loader');
+const babelMerge } = require('babel-merge');
 
-const together = merge(
+const together = babelMerge(
   {
     presets: [
       ['@babel/preset-env', {
@@ -123,13 +123,12 @@ console.log(together);
 ### Advanced merging
 
 Should you need to do merging of Babel configuration that is more advanced than this, such as re-ordering the options,
-you will need to `tap` into the existing Babel options to do so. This still involves using the compile-loader's
-`merge` function.
+you will need to `tap` into the existing Babel options to do so. This still involves using `babel-merge`.
 
 _Example: enable current decorator syntax in the compile loader:_
 
 ```js
-const { merge } = require('@neutrinojs/compile-loader');
+const babelMerge = require('babel-merge');
 
 // Decorators generally need to be enabled *before* other
 // syntax which exists in both normal plugins, and
@@ -140,7 +139,7 @@ const { merge } = require('@neutrinojs/compile-loader');
 config.module
   .rule('compile')
     .use('babel')
-      .tap(options => merge({
+      .tap(options => babelMerge({
         plugins: [
           require.resolve('@babel/plugin-proposal-decorators'),
           require.resolve('@babel/plugin-proposal-class-properties')

--- a/packages/compile-loader/index.js
+++ b/packages/compile-loader/index.js
@@ -1,4 +1,3 @@
-const babelMerge = require('babel-merge');
 const { DuplicateRuleError } = require('neutrino/errors');
 
 module.exports = (neutrino, { ruleId = 'compile', useId = 'babel', ...options } = {}) => {
@@ -27,5 +26,3 @@ module.exports = (neutrino, { ruleId = 'compile', useId = 'babel', ...options } 
       .get('options')
   );
 };
-
-module.exports.merge = babelMerge;

--- a/packages/compile-loader/package.json
+++ b/packages/compile-loader/package.json
@@ -24,8 +24,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.1.6",
-    "babel-loader": "^8.0.4",
-    "babel-merge": "^2.0.1"
+    "babel-loader": "^8.0.4"
   },
   "peerDependencies": {
     "neutrino": "^9.0.0-0",

--- a/packages/karma/index.js
+++ b/packages/karma/index.js
@@ -1,4 +1,4 @@
-const { merge: babelMerge } = require('@neutrinojs/compile-loader');
+const babelMerge = require('babel-merge');
 const merge = require('deepmerge');
 const omit = require('lodash.omit');
 const { join } = require('path');

--- a/packages/karma/package.json
+++ b/packages/karma/package.json
@@ -22,7 +22,7 @@
     "yarn": ">=1.2.1"
   },
   "dependencies": {
-    "@neutrinojs/compile-loader": "9.0.0-0",
+    "babel-merge": "^2.0.1",
     "babel-plugin-istanbul": "^5.1.0",
     "deepmerge": "^1.5.2",
     "karma-chrome-launcher": "^2.2.0",

--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -1,6 +1,7 @@
 const banner = require('@neutrinojs/banner');
 const compileLoader = require('@neutrinojs/compile-loader');
 const clean = require('@neutrinojs/clean');
+const babelMerge = require('babel-merge');
 const merge = require('deepmerge');
 const nodeExternals = require('webpack-node-externals');
 const { ConfigurationError } = require('neutrino/errors');
@@ -29,7 +30,7 @@ module.exports = (neutrino, opts = {}) => {
   }, opts);
 
   Object.assign(options, {
-    babel: compileLoader.merge({
+    babel: babelMerge({
       plugins: [
         require.resolve('@babel/plugin-syntax-dynamic-import')
       ],

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -36,6 +36,7 @@
     "@neutrinojs/banner": "9.0.0-0",
     "@neutrinojs/clean": "9.0.0-0",
     "@neutrinojs/compile-loader": "9.0.0-0",
+    "babel-merge": "^2.0.1",
     "deepmerge": "^1.5.2",
     "webpack-node-externals": "^1.7.2"
   },

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -1,7 +1,8 @@
 const banner = require('@neutrinojs/banner');
-const compile = require('@neutrinojs/compile-loader');
+const compileLoader = require('@neutrinojs/compile-loader');
 const clean = require('@neutrinojs/clean');
 const startServer = require('@neutrinojs/start-server');
+const babelMerge = require('babel-merge');
 const nodeExternals = require('webpack-node-externals');
 const {
   basename, parse, format
@@ -41,9 +42,9 @@ module.exports = (neutrino, opts = {}) => {
     }
   }, opts);
 
-  neutrino.use(compile, {
+  neutrino.use(compileLoader, {
     include: [neutrino.options.source, neutrino.options.tests],
-    babel: compile.merge({
+    babel: babelMerge({
       plugins: [
         require.resolve('@babel/plugin-syntax-dynamic-import')
       ],

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -30,6 +30,7 @@
     "@neutrinojs/clean": "9.0.0-0",
     "@neutrinojs/compile-loader": "9.0.0-0",
     "@neutrinojs/start-server": "9.0.0-0",
+    "babel-merge": "^2.0.1",
     "deepmerge": "^1.5.2",
     "lodash.omit": "^4.5.0",
     "webpack-node-externals": "^1.7.2"

--- a/packages/preact/index.js
+++ b/packages/preact/index.js
@@ -1,4 +1,4 @@
-const compileLoader = require('@neutrinojs/compile-loader');
+const babelMerge = require('babel-merge');
 const web = require('@neutrinojs/web');
 const merge = require('deepmerge');
 
@@ -6,7 +6,7 @@ module.exports = (neutrino, opts = {}) => {
   const options = {
     hot: true,
     ...opts,
-    babel: compileLoader.merge({
+    babel: babelMerge({
       plugins: [
         [require.resolve('@babel/plugin-transform-react-jsx'), { pragma: 'h' }],
         // Using loose for the reasons here:

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -27,8 +27,8 @@
     "@babel/core": "^7.1.6",
     "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/plugin-transform-react-jsx": "^7.1.6",
-    "@neutrinojs/compile-loader": "9.0.0-0",
     "@neutrinojs/web": "9.0.0-0",
+    "babel-merge": "^2.0.1",
     "deepmerge": "^1.5.2",
     "eslint-plugin-react": "^7.11.1"
   },

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -1,5 +1,5 @@
 const web = require('@neutrinojs/web');
-const compileLoader = require('@neutrinojs/compile-loader');
+const babelMerge = require('babel-merge');
 const merge = require('deepmerge');
 
 module.exports = (neutrino, opts = {}) => {
@@ -15,7 +15,7 @@ module.exports = (neutrino, opts = {}) => {
   } catch (err) {} // eslint-disable-line no-empty
 
   Object.assign(options, {
-    babel: compileLoader.merge({
+    babel: babelMerge({
       plugins: [
         // The RHL plugin is enabled in production too since it removes the `hot(module)(...)`
         // wrapper, allowing webpack to use its concatenate modules optimization.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,8 +27,8 @@
     "@babel/core": "^7.1.6",
     "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
-    "@neutrinojs/compile-loader": "9.0.0-0",
     "@neutrinojs/web": "9.0.0-0",
+    "babel-merge": "^2.0.1",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.20",
     "deepmerge": "^1.5.2",
     "eslint-plugin-react": "^7.11.1"

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -6,6 +6,7 @@ const compileLoader = require('@neutrinojs/compile-loader');
 const htmlTemplate = require('@neutrinojs/html-template');
 const clean = require('@neutrinojs/clean');
 const devServer = require('@neutrinojs/dev-server');
+const babelMerge = require('babel-merge');
 const merge = require('deepmerge');
 const { ConfigurationError } = require('neutrino/errors');
 
@@ -118,7 +119,7 @@ module.exports = (neutrino, opts = {}) => {
   }
 
   Object.assign(options, {
-    babel: compileLoader.merge({
+    babel: babelMerge({
       plugins: [
         require.resolve('@babel/plugin-syntax-dynamic-import')
       ],

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -34,6 +34,7 @@
     "@neutrinojs/html-template": "9.0.0-0",
     "@neutrinojs/image-loader": "9.0.0-0",
     "@neutrinojs/style-loader": "9.0.0-0",
+    "babel-merge": "^2.0.1",
     "deepmerge": "^1.5.2",
     "webpack-manifest-plugin": "^2.0.4"
   },


### PR DESCRIPTION
Since it's no longer a custom implementation and instead just the `babel-merge` package exported. As such it makes more sense for packages to import `babel-merge` directly iff they need it.

This also avoids the naming clash between `merge` from this preset and the typical import style used for `deepmerge` in this repository, that contributed to the bug fixed by #1219.