### PR TITLE
Move style extraction conditionals from web into style-loader

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -286,6 +286,9 @@ being set to a string [#1175](https://github.com/neutrinojs/neutrino/pull/1175).
 object using the [options here](https://webpack.js.org/configuration/dev-server/#devserver-proxy).
 - **BREAKING CHANGE** `@neutrinojs/web` and its dependent middleware no longer have the `options.hotEntries` option
 [#902](https://github.com/neutrinojs/neutrino/pull/902).
+- **BREAKING CHANGE** `@neutrinojs/web` and its dependent middleware no longer support
+`style.extract` being set to `true` [#1221](https://github.com/neutrinojs/neutrino/pull/1221).
+Override `style.extract.enabled` instead.
 - **BREAKING CHANGE** `@neutrinojs/web` and its dependent middleware no longer include `worker-loader` for automatically
 loading `*.worker.js` files [#1069](https://github.com/neutrinojs/neutrino/pull/1069).
 - **BREAKING CHANGE** The loading order for `config.resolve.extensions` has been rearranged to be closer in parity to

--- a/packages/style-loader/README.md
+++ b/packages/style-loader/README.md
@@ -64,6 +64,7 @@ neutrino.use(styles, {
   modulesTest: /\.module.css$/,
   extractId: 'extract',
   extract: {
+    enabled: process.env.NODE_ENV === 'production',
     loader: {},
     plugin: {
       filename: process.env.NODE_ENV === 'production'
@@ -100,6 +101,7 @@ module.exports = {
       modulesTest: /\.module.css$/,
       extractId: 'extract',
       extract: {
+        enabled: process.env.NODE_ENV === 'production',
         loader: {},
         plugin: {
           filename: process.env.NODE_ENV === 'production'
@@ -256,7 +258,7 @@ _Note: Some plugins may be only available in certain environments. To override t
 
 | Name | Description | NODE_ENV |
 | --- | --- | --- |
-| `extract` | Extracts CSS from JS bundle into a separate stylesheet file. | all |
+| `extract` | Extracts CSS from JS bundle into a separate stylesheet file. | `'production'` |
 
 ## Contributing
 

--- a/packages/vue/index.js
+++ b/packages/vue/index.js
@@ -10,7 +10,6 @@ module.exports = (neutrino, opts = {}) => {
     style: {
       ruleId: 'style',
       styleUseId: 'style',
-      extract: process.env.NODE_ENV === 'production',
       exclude: [],
       modulesTest: neutrino.regexFromExtensions(['css']),
       modulesSuffix: ''
@@ -30,9 +29,10 @@ module.exports = (neutrino, opts = {}) => {
 
   // vue-loader needs CSS files to be parsed with vue-style-loader instead of
   // style-loader, so we replace the loader with the one vue wants.
-  if (!options.style.extract) {
-    neutrino.config.module
-      .rule(options.style.ruleId)
+  // This is only required when using style-loader and not when extracting CSS.
+  const styleRule = neutrino.config.module.rules.get(options.style.ruleId);
+  if (styleRule && styleRule.uses.has(options.style.styleUseId)) {
+    styleRule
       .use(options.style.styleUseId)
       .loader(require.resolve('vue-style-loader'));
   }

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -193,12 +193,7 @@ module.exports = {
       publicPath: '/',
 
       // Change options for @neutrinojs/style-loader
-      style: {
-        // Disabling options.hot will also disable style.hot
-        hot: true,
-        // Extract CSS to a separate file in production.
-        extract: process.env.NODE_ENV === 'production'
-      },
+      style: {},
 
       // Change options for @neutrinojs/font-loader
       font: {},
@@ -488,7 +483,7 @@ _Note: Some plugins are only available in certain environments. To override them
 | Name | Description | NODE_ENV |
 | --- | --- | --- |
 | `env` | Inject environment variables into source code at `process.env`, using `EnvironmentPlugin`. | all |
-| `extract` | Extracts CSS from JS bundle into a separate stylesheet file. From `@neutrinojs/style-loader`. | all |
+| `extract` | Extracts CSS from JS bundle into a separate stylesheet file. From `@neutrinojs/style-loader`. | `'production'` |
 | `html-{MAIN_NAME}` | Automatically generates HTML files for configured entry points. `{MAIN_NAME}` corresponds to the entry point of each page. By default, there is only a single `index` main, so this would generate a plugin named `html-index`. From `@neutrinojs/html-template` | all |
 | `hot` | Enables Hot Module Replacement. | `'development'` |
 | `clean` | Removes the `build` directory prior to building. From `@neutrinojs/clean`. | `'production'` |

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -36,10 +36,7 @@ module.exports = (neutrino, opts = {}) => {
     devServer: {
       hot: opts.hot !== false
     },
-    style: {
-      hot: opts.hot !== false,
-      extract: isProduction
-    },
+    style: {},
     manifest: opts.html === false ? {} : false,
     clean: opts.clean !== false && {
       paths: [neutrino.options.output]
@@ -100,6 +97,12 @@ module.exports = (neutrino, opts = {}) => {
     };
   }
 
+  if (options.style && options.style.extract === true) {
+    throw new ConfigurationError(
+      'Setting `style.extract` to `true` is no longer supported. Override `style.extract.enabled` instead.'
+    );
+  }
+
   // Force @babel/preset-env default behavior (.browserslistrc)
   if (options.targets === false) {
     options.targets = {};
@@ -115,9 +118,6 @@ module.exports = (neutrino, opts = {}) => {
   }
 
   Object.assign(options, {
-    style: options.style && merge(options.style, {
-      extract: options.style.extract === true ? {} : options.style.extract
-    }),
     babel: compileLoader.merge({
       plugins: [
         require.resolve('@babel/plugin-syntax-dynamic-import')

--- a/packages/web/test/web_test.js
+++ b/packages/web/test/web_test.js
@@ -302,6 +302,14 @@ test('throws when devServer.proxy is the deprecated string shorthand', t => {
   );
 });
 
+test('throws when style.extract is true', t => {
+  const api = new Neutrino();
+  t.throws(
+    () => api.use(mw(), { style: { extract: true } }),
+    /Setting `style.extract` to `true` is no longer supported/
+  );
+});
+
 test('targets option test', t => {
   const api = new Neutrino();
   const targets = {


### PR DESCRIPTION
Previously the `NODE_ENV` check for determining whether to enable stylesheet extraction existed only in `@neutrinojs/web`, meaning that if `@neutrinojs/style-loader` was manually used (either on its own or in coordination with the web preset), then extraction would be incorrectly enabled in development.

The `style.extract = false` shorthand of always disabling extraction still works, however `style.extract = true` must now be replaced by `style.extract.enabled = true` (though I believe that style is not likely to have been used by many projects, since it's more common to want to disable in production than enable in development).