### PR TITLE
jest: Add missing peer dependency

### DIFF
--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -22,7 +22,8 @@
     "yarn": ">=1.2.1"
   },
   "dependencies": {
-    "babel-core": "^7.0.0-bridge",
+    "@babel/core": "^7.1.6",
+    "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.6.0",
     "deepmerge": "^1.5.2",
     "eslint-plugin-jest": "^22.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1551,7 +1551,7 @@ babel-core@^6.0.0, babel-core@^6.26.0:
     slash "^1.0.0"
     source-map "^0.5.7"
 
-babel-core@^7.0.0-bridge:
+babel-core@^7.0.0-bridge.0:
   version "7.0.0-bridge.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
   integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==


### PR DESCRIPTION
Fixes:

```
warning ... > @neutrinojs/jest > babel-core@7.0.0-bridge.0" has unmet
peer dependency "@babel/core@^7.0.0-0".
```