### PR TITLE
Stop adding .wasm to the compile/linting rules

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -178,7 +178,7 @@ information, inspecting processes, or changing configuration which is helpful fo
 ### `options.extensions`
 
 Informs interested middleware the preferred list of module extensions to support.
-By default, `options.extensions` is set to `['wasm', 'mjs', 'vue', 'jsx', 'tsx', 'ts', 'js']`.
+By default, `options.extensions` is set to `['mjs', 'jsx', 'js']`.
 
 ### `options.packageJson`
 
@@ -303,6 +303,6 @@ without any parameters which fallback to `neutrino.options.extensions`.
 // resolves to /\.(vue|js)$/
 neutrino.regexFromExtensions(['vue', 'js']);
 
-// defaults neutrino.options.extensions which resolves to /\.(wasm|mjs|vue|jsx|tsx|ts|js)$/
+// defaults neutrino.options.extensions which resolves to /\.(mjs|jsx|js)$/
 neutrino.regexFromExtensions();
 ```

--- a/docs/creating-presets.md
+++ b/docs/creating-presets.md
@@ -294,11 +294,11 @@ module.exports = {
 ### `options.extensions`
 
 Set the preferred list of module extensions to inform interested middleware. If the option is not set,
-Neutrino defaults it to `['wasm', 'mjs', 'vue', 'jsx', 'tsx', 'ts', 'js']`.
+Neutrino defaults it to `['mjs', 'jsx', 'js']`.
 
 ```js
 module.exports = neutrino => {
-  // if not specified, defaults to ['wasm', 'mjs', 'vue', 'jsx', 'tsx', 'ts', 'js']
+  // if not specified, defaults to ['mjs', 'jsx', 'js']
   neutrino.options.extensions;
 
   // overwrites the default list
@@ -307,7 +307,7 @@ module.exports = neutrino => {
 
 module.exports = {
   options: {
-    // extends the default list to ['wasm', 'mjs', 'vue', 'jsx', 'tsx', 'ts', 'js', 'elm']
+    // extends the default list to ['mjs', 'jsx', 'js', 'elm']
     extensions: ['elm']
   }
 };

--- a/packages/airbnb-base/test/airbnb_test.js
+++ b/packages/airbnb-base/test/airbnb_test.js
@@ -62,7 +62,7 @@ test('sets defaults when no options passed', t => {
   api.use(mw());
 
   const lintRule = api.config.module.rule('lint');
-  t.deepEqual(lintRule.get('test'), /\.(wasm|mjs|jsx|js)$/);
+  t.deepEqual(lintRule.get('test'), /\.(mjs|jsx|js)$/);
   t.deepEqual(lintRule.include.values(), [api.options.source, api.options.tests]);
   t.deepEqual(lintRule.exclude.values(), []);
   t.deepEqual(lintRule.use('eslint').get('options'), {

--- a/packages/airbnb/test/airbnb_test.js
+++ b/packages/airbnb/test/airbnb_test.js
@@ -62,7 +62,7 @@ test('sets defaults when no options passed', t => {
   api.use(mw());
 
   const lintRule = api.config.module.rule('lint');
-  t.deepEqual(lintRule.get('test'), /\.(wasm|mjs|jsx|js)$/);
+  t.deepEqual(lintRule.get('test'), /\.(mjs|jsx|js)$/);
   t.deepEqual(lintRule.include.values(), [api.options.source, api.options.tests]);
   t.deepEqual(lintRule.exclude.values(), []);
   t.deepEqual(lintRule.use('eslint').get('options'), {

--- a/packages/eslint/test/middleware_test.js
+++ b/packages/eslint/test/middleware_test.js
@@ -118,7 +118,7 @@ test('sets defaults when no options passed', t => {
   api.use(mw());
 
   const lintRule = api.config.module.rule('lint');
-  t.deepEqual(lintRule.get('test'), /\.(wasm|mjs|jsx|js)$/);
+  t.deepEqual(lintRule.get('test'), /\.(mjs|jsx|js)$/);
   t.deepEqual(lintRule.include.values(), [api.options.source, api.options.tests]);
   t.deepEqual(lintRule.exclude.values(), []);
   t.deepEqual(lintRule.use('eslint').get('options'), {
@@ -331,7 +331,7 @@ test('sets only loader-specific defaults if useEslintrc true', t => {
   api.use(mw(), { eslint: { useEslintrc: true } });
 
   const lintRule = api.config.module.rule('lint');
-  t.deepEqual(lintRule.get('test'), /\.(wasm|mjs|jsx|js)$/);
+  t.deepEqual(lintRule.get('test'), /\.(mjs|jsx|js)$/);
   t.deepEqual(lintRule.include.values(), [api.options.source, api.options.tests]);
   t.deepEqual(lintRule.exclude.values(), []);
   t.deepEqual(lintRule.use('eslint').get('options'), {

--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -76,7 +76,14 @@ module.exports = (neutrino, opts = {}) => {
       .end()
     .resolve
       .extensions
-        .merge(neutrino.options.extensions.concat('json').map(ext => `.${ext}`))
+        // Based on the webpack defaults:
+        // https://webpack.js.org/configuration/resolve/#resolve-extensions
+        // Keep in sync with the options in the node and web presets.
+        .merge([
+          '.wasm',
+          ...neutrino.options.extensions.map(ext => `.${ext}`),
+          '.json'
+        ])
         .end()
       .end()
     .node

--- a/packages/neutrino/extensions.js
+++ b/packages/neutrino/extensions.js
@@ -4,7 +4,7 @@ module.exports = {
   // Modifying a value here should have an accompanying change there as well.
   // We can't pull in neutrino there as that would potentially give us
   // conflicting versions in node_modules.
-  source: ['wasm', 'mjs', 'jsx', 'js'],
+  source: ['mjs', 'jsx', 'js'],
   style: ['css', 'less', 'sass', 'scss'],
   media: [
     'jpg',

--- a/packages/neutrino/test/api_test.js
+++ b/packages/neutrino/test/api_test.js
@@ -197,6 +197,7 @@ test('creates a webpack config', t => {
 test('regexFromExtensions', t => {
   const api = new Neutrino();
 
+  t.is(String(api.regexFromExtensions()), '/\\.(mjs|jsx|js)$/');
   t.is(String(api.regexFromExtensions(['js'])), '/\\.js$/');
   t.is(String(api.regexFromExtensions(['js', 'css'])), '/\\.(js|css)$/');
   t.is(String(api.regexFromExtensions(['worker.js', 'worker.jsx'])), '/\\.(worker\\.js|worker\\.jsx)$/');

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -77,7 +77,14 @@ module.exports = (neutrino, opts = {}) => {
       .end()
     .resolve
       .extensions
-        .merge(neutrino.options.extensions.concat('json').map(ext => `.${ext}`))
+        // Based on the webpack defaults:
+        // https://webpack.js.org/configuration/resolve/#resolve-extensions
+        // Keep in sync with the options in the web and library presets.
+        .merge([
+          '.wasm',
+          ...neutrino.options.extensions.map(ext => `.${ext}`),
+          '.json'
+        ])
         .end()
       .end()
     // The default output is too noisy, particularly with multiple entrypoints.

--- a/packages/standardjs/test/standardjs_test.js
+++ b/packages/standardjs/test/standardjs_test.js
@@ -62,7 +62,7 @@ test('sets defaults when no options passed', t => {
   api.use(mw());
 
   const lintRule = api.config.module.rule('lint');
-  t.deepEqual(lintRule.get('test'), /\.(wasm|mjs|jsx|js)$/);
+  t.deepEqual(lintRule.get('test'), /\.(mjs|jsx|js)$/);
   t.deepEqual(lintRule.include.values(), [api.options.source, api.options.tests]);
   t.deepEqual(lintRule.exclude.values(), []);
   t.deepEqual(lintRule.use('eslint').get('options'), {

--- a/packages/vue/test/vue_test.js
+++ b/packages/vue/test/vue_test.js
@@ -50,7 +50,7 @@ test('updates lint config by default', t => {
   api.use(mw());
 
   const lintRule = api.config.module.rule('lint');
-  t.deepEqual(lintRule.get('test'), /\.(wasm|mjs|jsx|vue|js)$/);
+  t.deepEqual(lintRule.get('test'), /\.(mjs|jsx|vue|js)$/);
   t.deepEqual(lintRule.use('eslint').get('options').baseConfig, {
     env: {
       browser: true,

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -206,7 +206,14 @@ module.exports = (neutrino, opts = {}) => {
       .end()
     .resolve
       .extensions
-        .merge(neutrino.options.extensions.concat('json').map(ext => `.${ext}`))
+        // Based on the webpack defaults:
+        // https://webpack.js.org/configuration/resolve/#resolve-extensions
+        // Keep in sync with the options in the node and library presets.
+        .merge([
+          '.wasm',
+          ...neutrino.options.extensions.map(ext => `.${ext}`),
+          '.json'
+        ])
         .end()
       .end()
     .node


### PR DESCRIPTION
...and only to `resolve.extensions`.

Fixes #1179.