### PR TITLE
Docs: Preparation for Neutrino 9 release

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -306,7 +306,7 @@ check and test your project to ensure proper functionality.
 - ESLint caching is now enabled by default for new projects, so it is recommended to specify `.eslintcache` as being
 ignored from your source control commits.
 
-[Compare all v9 changes](https://github.com/neutrinojs/neutrino/compare/v8.3.0...master)
+[Compare all v9 changes](https://github.com/neutrinojs/neutrino/compare/v8.3.0...v9.0.0)
 
 ## Neutrino v7 to v8
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,7 +65,7 @@ nav:
   - API: './api.md'
   - Creating Presets: './creating-presets.md'
   - Previous Versions:
-    - v8 Documentation: 'https://neutrinojs.org/'
+    - v8 Documentation: 'https://release-v8.neutrinojs.org/'
     - v7 Documentation: 'https://release-v7.neutrinojs.org/'
     - v6 Documentation: 'https://github.com/neutrinojs/neutrino/tree/release/v6/docs'
     - v5 Documentation: 'https://github.com/neutrinojs/neutrino/tree/release/v5/docs'


### PR DESCRIPTION
The Git tag and subdomain don't yet exist, but we need these in place first. (It's not possible to add the subdomain on Netlify yet, since they don't allow double-deploying the same branch to the main site and a subdomain.)

See #1132.