### PR TITLE
Vue/Style: Use passed style.test option as default instead of forcing css

### DIFF
--- a/packages/vue/index.js
+++ b/packages/vue/index.js
@@ -11,7 +11,7 @@ module.exports = (neutrino, opts = {}) => {
       ruleId: 'style',
       styleUseId: 'style',
       exclude: [],
-      modulesTest: neutrino.regexFromExtensions(['css']),
+      modulesTest: opts.style && opts.style.test ? opts.style.test : neutrino.regexFromExtensions(['css']),
       modulesSuffix: ''
     }
   }, opts);


### PR DESCRIPTION
```
neutrino => neutrino.use('@neutrinojs/vue', {
    style: {
          test: /\.s?css$/,
       }
})
```

The vue preset changes the default for `style.modulesTest`, but just defaults to css extensions.
If you are already overriding the `test` option, chances are you'll want it to use that as a default.

Note: in the past we've used `Ramda.pathOr` for this kind of nested accessor. It seemed like it had been mostly yanked from middlewares, so I did it the long way :)