### PR TITLE
Only default to chunks to 'all' when using generated html.

### DIFF
--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -180,7 +180,7 @@ module.exports = (neutrino, opts = {}) => {
         // ever-changing file list breaking users who don't auto-generate their HTML):
         // https://webpack.js.org/plugins/split-chunks-plugin/#optimization-splitchunks-chunks-all
         // https://github.com/webpack/webpack/issues/7064
-        chunks: 'all',
+        chunks: options.html ? 'all' : 'async',
         // Override the default limit of 3 chunks per entrypoint in production, since
         // it speeds up builds and the greater number of requests is mitigated by use
         // of long term caching (and a non-issue if using HTTP2).


### PR DESCRIPTION
This seems like a better default, as if you're _not_ using html-webpack-plugin/auto-generated html (`html: false`), you're likely relying on a manifest.json and need predictable chunk names.

And/or to make this easier to configure, we could expose the splitChunks config object as an option for  @neutrinojs/web.

Thoughts?