### PR TITLE
Issue 1198 - React create-project example page text is missing a space between words

### DIFF
--- a/packages/create-project/commands/init/templates/react/src/App.jsx
+++ b/packages/create-project/commands/init/templates/react/src/App.jsx
@@ -12,8 +12,7 @@ class App extends Component {
     return (
       <div className="App">
         <h1>
-          Welcome to
-          {name}
+          Welcome to {name}
         </h1>
       </div>
     );


### PR DESCRIPTION
Just removed the line break and added a space. This closes the issue 1198. 