### PR TITLE
create-project: Display lint command output when using --debug

### DIFF
--- a/packages/create-project/bin/create-project.js
+++ b/packages/create-project/bin/create-project.js
@@ -24,5 +24,6 @@ env.run('create-project', {
   directory,
   name,
   registry: cli.registry,
+  debug: !!cli.debug,
   stdio: cli.debug ? 'inherit' : 'ignore'
 }, done);


### PR DESCRIPTION
Previously the stdout/stderr of the "initial lint" step was not shown as expected when `--debug` had been passed to `create-project`. Now the full console output is displayed inline, like was already the case for the package install steps.

The yeoman `spawnCommandSync()` options have also been refactored to reduce duplication, and the error handling adjusted so that:
- a user friendly message is still shown in the case of `result.error`
- the suggestion to use `--debug` is not shown if it was already passed
- there is no longer a verbose Neutrino stack trace shown

See:
https://yeoman.github.io/generator/Generator.html#spawnCommandSync
https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options

Fixes #1262.