### PR TITLE
create-project: Run correct command for initial lint when using npm

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -187,7 +187,7 @@ if desired.
 }
 ```
 
-Note: When using NPM any options must be preceeded with `--`, so the `lint:fix` command
+Note: When using npm any options must be preceeded with `--`, so the `lint:fix` command
 becomes `"npm run lint -- --fix"`.
 
 To tell ESLint to load Neutrino middleware or presets for its configuration, create a

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -187,6 +187,9 @@ if desired.
 }
 ```
 
+Note: When using NPM any options must be preceeded with `--`, so the `lint:fix` command
+becomes `"npm run lint -- --fix"`.
+
 To tell ESLint to load Neutrino middleware or presets for its configuration, create a
 `.eslintrc.js` file in the root of the project with the following:
 

--- a/packages/create-project/commands/init/index.js
+++ b/packages/create-project/commands/init/index.js
@@ -242,7 +242,7 @@ module.exports = class Project extends Generator {
       this._spawnSync(packageManager,
         isYarn
           ? ['lint', '--fix']
-          : ['run', 'lint', '--fix']
+          : ['run', 'lint', '--', '--fix']
       );
     }
   }
@@ -261,8 +261,10 @@ module.exports = class Project extends Generator {
     }
 
     if (this.data.linter) {
-      this.log(`  • To lint your project manually run:  ${chalk.cyan.bold(`${isYarn ? 'yarn' : 'npm run'} lint`)}`);
-      this.log(`    You can also fix some linting problems with:  ${chalk.cyan.bold(`${isYarn ? 'yarn' : 'npm run'} lint --fix`)}`);
+      const lintCommand = isYarn ? 'yarn lint' : 'npm run lint';
+      const fixLintCommand = isYarn ? `${lintCommand} --fix` : `${lintCommand} -- --fix`;
+      this.log(`  • To lint your project manually run:  ${chalk.cyan.bold(lintCommand)}`);
+      this.log(`    You can also fix linting problems with:  ${chalk.cyan.bold(fixLintCommand)}`);
     }
 
     this.log('\nNow change your directory to the following to get started:');


### PR DESCRIPTION
Previously the `--fix` option was not passed to ESLint when using NPM, since it requires that any options passed be preceded with `--`.

This caused failures during create-project when users picked a lint preset whose style differed from the template project, since the failures would not be fixed, and instead ESLint exit non-zero causing create-project to abort and delete the new project.

Fixes #1261.

(The create-project tests currently only run the preset test matrix using yarn - I've opened #1264 for adding coverage of NPM too.)