### PR TITLE
create-project: Skip directory cleanup on errors when using debug

### DIFF
--- a/packages/create-project/commands/init/index.js
+++ b/packages/create-project/commands/init/index.js
@@ -47,10 +47,11 @@ module.exports = class Project extends Generator {
       this.log.error(`The command "${commandString}" exited unsuccessfully.`);
 
       if (!this.options.debug) {
-        this.log.error('Try again with the --debug flag for more detailed information about the failure.');
+        this.log.error('Cleaning up the incomplete project directory.');
+        removeSync(this.options.directory);
+        this.log.error('Try again with the --debug flag for more information and to skip cleanup.');
       }
 
-      removeSync(this.options.directory);
       process.exit(result.status || 1);
     }
 


### PR DESCRIPTION
Previously the newly create project directory was always removed if errors occurred during any of `create-project`'s install/lint steps, making debugging hard. Now if the `--debug` option is used cleanup is skipped, allowing the user to manually try the command that was failing inside the incomplete project directory.

Fixes #1263.