### PR TITLE
Vue: Allow css modules to co-exist with global styles

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -321,6 +321,7 @@ module.exports = {
 ```
 
 - **BREAKING CHANGE** `@neutrinojs/style-loader` now creates a single `style` rule with `oneOfs`, instead of multiple rules for handling css modules ((#1281)[https://github.com/neutrinojs/neutrino/pull/1281]).
+- **BREAKING CHANGE** `@neutrinojs/vue` now adds oneOfs instead of replacing existing style rules ((#1276)[https://github.com/neutrinojs/neutrino/pull/1276]).
 - ESLint caching is now enabled by default for new projects, so it is recommended to specify `.eslintcache` as being
 ignored from your source control commits.
 

--- a/packages/neutrino/package.json
+++ b/packages/neutrino/package.json
@@ -28,7 +28,7 @@
     "deepmerge": "^1.5.2",
     "is-plain-object": "^2.0.4",
     "lodash.clonedeep": "^4.5.0",
-    "webpack-chain": "^5.0.1",
+    "webpack-chain": "^5.1.0",
     "yargs-parser": "^11.1.1"
   }
 }

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -290,12 +290,14 @@ If the need arises, you can also compile `node_modules` by referring to the rele
 
 ### Rules
 
-The following is a list of additional rules and their identifiers this preset defines, in addition
+The following is a list of additional rules/oneOfs and their identifiers this preset defines, in addition
 to the ones provided by `@neutrinojs/web`, which can be overridden:
 
 | Name | Description | NODE_ENV |
 | --- | --- | --- |
 | `vue` | Compiles Vue files from the `src` directory using Babel and `vue-loader`. Contains a single loader named `vue`. | all |
+| `style.vue-normal` | oneOf rule for importing CSS from `<style>` in Vue components. | all |
+| `style.vue-modules` | oneOf rule for importing CSS modules from `<style module>` from Vue components. | all |
 
 ### Plugins
 

--- a/packages/vue/index.js
+++ b/packages/vue/index.js
@@ -31,23 +31,31 @@ module.exports = (neutrino, opts = {}) => {
   const styleRule = neutrino.config.module.rules.get(options.style.ruleId);
   const styleModulesRule = neutrino.config.module.rules.get(`${options.style.ruleId}${options.style.modulesSuffix}`);
 
+  if (styleRule && styleRule.uses.has(options.style.styleUseId)) {
+    styleRule
+      .use(`${options.style.styleUseId}`)
+      .loader(require.resolve('vue-style-loader'));
+  }
+
+  if (styleModulesRule && styleModulesRule.uses.has(`${options.style.styleUseId}${options.style.modulesSuffix}`)) {
+    styleModulesRule
+      .use(`${options.style.styleUseId}${options.style.modulesSuffix}`)
+      .loader(require.resolve('vue-style-loader'));
+  }
+
   styleRule
     .oneOf(`vue-${options.style.ruleId}${options.style.modulesSuffix}`)
       .resourceQuery(/module/)
       .uses
         .merge(styleModulesRule.uses.entries())
         .end()
-      .use(`${options.style.styleUseId}${options.style.modulesSuffix}`)
-        .loader(require.resolve('vue-style-loader'))
-        .end()
+      .end()
     .oneOf(`vue-${options.style.ruleId}`)
       .resourceQuery(/\?vue/)
       .uses
         .merge(styleRule.uses.entries())
         .end()
-      .use(options.style.styleUseId)
-        .loader(require.resolve('vue-style-loader'))
-        .end()
+      .end()
     .oneOf(options.style.ruleId)
       .uses
         .merge(styleRule.uses.entries())

--- a/packages/vue/index.js
+++ b/packages/vue/index.js
@@ -36,6 +36,7 @@ module.exports = (neutrino, opts = {}) => {
       });
   });
 
+  // Rebuild our style rule to be a oneOf, first matching vue component styles
   styleRule
     .oneOf(`vue-${options.style.ruleId}${options.style.modulesSuffix}`)
       .resourceQuery(/module/)

--- a/packages/vue/index.js
+++ b/packages/vue/index.js
@@ -6,7 +6,8 @@ module.exports = (neutrino, opts = {}) => {
     style: {
       ruleId: 'style',
       styleUseId: 'style',
-      modulesSuffix: '-modules'
+      modulesSuffix: '-modules',
+      modules: true
     }
   }, opts);
 
@@ -38,12 +39,12 @@ module.exports = (neutrino, opts = {}) => {
 
   // Rebuild our style rule to be a oneOf, first matching vue component styles
   styleRule
-    .oneOf(`vue-${options.style.ruleId}${options.style.modulesSuffix}`)
-      .resourceQuery(/module/)
-      .uses
-        .merge(styleModulesRule.uses.entries())
-        .end()
-      .end()
+    .when(styleModulesRule && options.style.modules, rule => {
+      rule.oneOf(`vue-${options.style.ruleId}${options.style.modulesSuffix}`)
+        .resourceQuery(/module/)
+        .uses
+          .merge(styleModulesRule.uses.entries());
+    })
     .oneOf(`vue-${options.style.ruleId}`)
       .resourceQuery(/\?vue/)
       .uses

--- a/packages/vue/index.js
+++ b/packages/vue/index.js
@@ -2,10 +2,6 @@ const web = require('@neutrinojs/web');
 const merge = require('deepmerge');
 
 module.exports = (neutrino, opts = {}) => {
-  // vue-loader extracts <style> tags to CSS files so they are parsed
-  // automatically by the css-loader. In order to enable CSS modules
-  // on these CSS files, we need to say that normal CSS files can use
-  // CSS modules.
   const options = merge({
     style: {
       ruleId: 'style',

--- a/packages/vue/index.js
+++ b/packages/vue/index.js
@@ -31,17 +31,14 @@ module.exports = (neutrino, opts = {}) => {
   const styleRule = neutrino.config.module.rules.get(options.style.ruleId);
   const styleModulesRule = neutrino.config.module.rules.get(`${options.style.ruleId}${options.style.modulesSuffix}`);
 
-  if (styleRule && styleRule.uses.has(options.style.styleUseId)) {
-    styleRule
-      .use(`${options.style.styleUseId}`)
-      .loader(require.resolve('vue-style-loader'));
-  }
-
-  if (styleModulesRule && styleModulesRule.uses.has(`${options.style.styleUseId}${options.style.modulesSuffix}`)) {
-    styleModulesRule
-      .use(`${options.style.styleUseId}${options.style.modulesSuffix}`)
-      .loader(require.resolve('vue-style-loader'));
-  }
+  [styleRule, styleModulesRule].forEach(rule => {
+    rule
+      .when(rule && rule.uses.has(options.style.styleUseId), rule => {
+        rule
+          .use(`${options.style.styleUseId}`)
+          .loader(require.resolve('vue-style-loader'));
+      });
+  });
 
   styleRule
     .oneOf(`vue-${options.style.ruleId}${options.style.modulesSuffix}`)
@@ -61,7 +58,8 @@ module.exports = (neutrino, opts = {}) => {
         .merge(styleRule.uses.entries())
         .end()
       .end()
-    .uses.clear();
+    .uses
+      .clear();
 
   neutrino.config.module
     .rule('vue')

--- a/packages/vue/test/vue_test.js
+++ b/packages/vue/test/vue_test.js
@@ -97,11 +97,16 @@ test('adds style oneOfs in order', t => {
   ]);
 });
 
-test('replaces style-loader with vue-style-loader', t => {
+test('replaces style-loader with vue-style-loader in development', t => {
+  process.env.NODE_ENV = 'development';
   const api = new Neutrino();
   api.use(mw());
 
-  api.config.module.rule('style').oneOfs.values().filter(oneOf => oneOf.name.startsWith('vue-')).forEach(oneOf => {
-    t.is(oneOf.use('style').get('loader'), require.resolve('vue-style-loader'));
-  });
+  api.config.module.rule('style')
+    .oneOfs
+    .values()
+    .filter(oneOf => oneOf.name.startsWith('vue-'))
+    .forEach(oneOf => {
+      t.is(oneOf.use('style').get('loader'), require.resolve('vue-style-loader'));
+    });
 });

--- a/packages/vue/test/vue_test.js
+++ b/packages/vue/test/vue_test.js
@@ -84,3 +84,25 @@ test('does not update lint config if useEslintrc true', t => {
   const options = api.config.module.rule('lint').use('eslint').get('options');
   t.deepEqual(options.baseConfig, {});
 });
+
+test('adds style oneOfs in order', t => {
+  const api = new Neutrino();
+  api.use(mw());
+  const { oneOfs } = api.config.module.rule('style');
+
+  t.is(Object.keys(oneOfs.entries()), [
+    'vue-modules',
+    'vue-normal',
+    'modules',
+    'normal'
+  ]);
+});
+
+test('replaces style-loader with vue-style-loader', t => {
+  const api = new Neutrino();
+  api.use(mw());
+
+  api.config.module.rule('style').oneOfs.values().filter(oneOf => oneOf.name.startsWith('vue-')).forEach(oneOf => {
+    t.is(oneOf.use('style').get('loader'), require.resolve('vue-style-loader'));
+  });
+});

--- a/packages/vue/test/vue_test.js
+++ b/packages/vue/test/vue_test.js
@@ -90,7 +90,7 @@ test('adds style oneOfs in order', t => {
   api.use(mw());
   const { oneOfs } = api.config.module.rule('style');
 
-  t.is(Object.keys(oneOfs.entries()), [
+  t.deepEqual(Object.keys(oneOfs.entries()), [
     'vue-modules',
     'vue-normal',
     'modules',

--- a/packages/vue/test/vue_test.js
+++ b/packages/vue/test/vue_test.js
@@ -89,7 +89,6 @@ test('adds style oneOfs in order', t => {
   const api = new Neutrino();
   api.use(mw());
   const { oneOfs } = api.config.module.rule('style');
-
   t.deepEqual(Object.keys(oneOfs.entries()), [
     'vue-modules',
     'vue-normal',

--- a/packages/vue/test/vue_test.js
+++ b/packages/vue/test/vue_test.js
@@ -89,7 +89,7 @@ test('adds style oneOfs in order', t => {
   const api = new Neutrino();
   api.use(mw());
   const { oneOfs } = api.config.module.rule('style');
-  t.deepEqual(Object.keys(oneOfs.entries()), [
+  t.deepEqual(oneOfs.values().map(oneOf => oneOf.name), [
     'vue-modules',
     'vue-normal',
     'modules',

--- a/yarn.lock
+++ b/yarn.lock
@@ -12358,10 +12358,10 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
-webpack-chain@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/webpack-chain/-/webpack-chain-5.0.1.tgz#549ec483f1bd6699ad4305b7892869cd619c1b62"
-  integrity sha512-RiMJSZ5bxURnRl1hLOjslWD9aqqBRjwLUFvYR1Nq7dxka4fYw/mLPS0X641qJd3f4SLuiZ7k8WSiss8XgTTl1w==
+webpack-chain@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/webpack-chain/-/webpack-chain-5.1.0.tgz#106d6a1848d7a996465568e1a04e3380580aee17"
+  integrity sha512-FWMw3zyXOdSkU+VYCtRid7i9PJ4H7Zp8NnBM3U+7DBDcPw4WQ7KGkBlRerfcZ3zk8qX77RoU0w57LGU1OFFMlg==
   dependencies:
     deepmerge "^1.5.2"
     javascript-stringify "^1.6.0"


### PR DESCRIPTION
Fixes #1243 

This converts the style rule to a oneOf, to allow for both global and module styes. The `oneOf` approach was cribbed from https://github.com/vuejs/vue-cli/blob/b559005ce64dc801c280e38194f28dd583292095/packages/%40vue/cli-service/lib/config/css.js#L72

> I'm also wondering if restructuring the style and style-modules rule created by style-loader into oneofs might make things easier to deal with? Wouldn't have to worry about multiple applied rules and excluding things, etc.
- https://github.com/neutrinojs/neutrino/issues/1243#issuecomment-450875429: 