### PR TITLE
karma: Remove no longer required karma-webpack hangs workaround

### DIFF
--- a/packages/karma/index.js
+++ b/packages/karma/index.js
@@ -70,17 +70,7 @@ module.exports = (neutrino, options = {}) => {
           warnings: true
         }
       },
-      webpack: merge(
-        omit(neutrino.config.toConfig(), ['entry']),
-        // Work around `yarn test` hanging under webpack 4:
-        // https://github.com/webpack-contrib/karma-webpack/issues/322
-        {
-          optimization: {
-            splitChunks: false,
-            runtimeChunk: false
-          }
-        }
-      ),
+      webpack: omit(neutrino.config.toConfig(), ['entry']),
       reporters: ['mocha', 'coverage'],
       coverageReporter: {
         dir: '.coverage',


### PR DESCRIPTION
Since the underlying issue (webpack-contrib/karma-webpack#322) is now fixed in the latest RC of karma-webpack.