### PR TITLE
Update dependency webpack-dev-server to v3.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "verdaccio-memory": "^1.0.3",
     "webpack": "^4.26.1",
     "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.10"
+    "webpack-dev-server": ">=3.1.11"
   },
   "lint-staged": {
     "*.js": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -12149,7 +12149,7 @@ webpack-dev-middleware@^3.2.0:
     range-parser "^1.0.3"
     webpack-log "^2.0.0"
 
-webpack-dev-server@^3.1.10:
+webpack-dev-server@>=3.1.11:
   version "3.1.14"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.1.14.tgz#60fb229b997fc5a0a1fc6237421030180959d469"
   integrity sha512-mGXDgz5SlTxcF3hUpfC8hrQ11yhAttuUQWf1Wmb+6zo3x6rb7b9mIfuQvAPLdfDRCGRGvakBWHdHOa0I9p/EVQ==


### PR DESCRIPTION
This PR updates the webpack-dev-server dependency to resolve vulnerability issue.

**Reference Screenshot:**
![screenshot 2019-02-14 at 11 35 31 am](https://user-images.githubusercontent.com/7814557/52766745-2b16af00-304e-11e9-9e8f-a6e66017e762.png)
