### PR TITLE
jest: Exclude mjs from moduleFileExtensions

### DIFF
--- a/packages/jest/src/index.js
+++ b/packages/jest/src/index.js
@@ -52,6 +52,9 @@ module.exports = (options = {}) => (neutrino) => {
       moduleDirectories: modulesConfig.length ? modulesConfig : ['node_modules'],
       moduleFileExtensions: neutrino.config.resolve.extensions
         .values()
+        // Jest does not yet support ES6 modules, see:
+        // https://github.com/facebook/jest/issues/4842
+        .filter(ext => ext !== '.mjs')
         .map(extension => extension.replace('.', '')),
       moduleNameMapper:
         Object

--- a/packages/jest/test/jest_test.js
+++ b/packages/jest/test/jest_test.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 import airbnbPreset from '../../airbnb';
 import eslintPreset from '../../eslint';
+import reactPreset from '../../react';
 import Neutrino from '../../neutrino/Neutrino';
 import neutrino from '../../neutrino';
 
@@ -93,4 +94,19 @@ test('does not update lint config if useEslintrc true', t => {
   api.use(mw());
   const options = api.config.module.rule('lint').use('eslint').get('options');
   t.deepEqual(options.baseConfig, {});
+});
+
+test('configures moduleFileExtensions correctly', t => {
+  const api = new Neutrino();
+  api.use(reactPreset());
+  api.use(mw());
+  const config = api.outputHandlers.get('jest')(api);
+  t.deepEqual(config.moduleFileExtensions, [
+    'web.jsx',
+    'web.js',
+    'wasm',
+    'jsx',
+    'js',
+    'json'
+  ]);
 });


### PR DESCRIPTION
Since Jest does not yet support ES6 modules, so will error if imports resolve to `.mjs` files.

Fixes #1326.