### PR TITLE
Improve migration documentation and add more legacy option checks

### DIFF
--- a/packages/neutrino/Neutrino.js
+++ b/packages/neutrino/Neutrino.js
@@ -38,6 +38,18 @@ module.exports = class Neutrino {
       );
     }
 
+    if ('host' in options) {
+      throw new ConfigurationError(
+        'options.host has been removed. Configure via the `devServer.host` option of the web/react/... presets.'
+      );
+    }
+
+    if ('port' in options) {
+      throw new ConfigurationError(
+        'options.port has been removed. Configure via the `devServer.port` option of the web/react/... presets.'
+      );
+    }
+
     if (!options.mains) {
       Object.assign(options, {
         mains: {

--- a/packages/neutrino/test/api_test.js
+++ b/packages/neutrino/test/api_test.js
@@ -69,6 +69,14 @@ test('throws when legacy options.node_modules is set', t => {
   t.throws(() => new Neutrino({ node_modules: 'abc' }), /options\.node_modules has been removed/);
 });
 
+test('throws when legacy options.host is set', t => {
+  t.throws(() => new Neutrino({ host: 'abc' }), /options\.host has been removed/);
+});
+
+test('throws when legacy options.port is set', t => {
+  t.throws(() => new Neutrino({ port: 1234 }), /options\.port has been removed/);
+});
+
 test('options.mains', t => {
   const api = new Neutrino();
 


### PR DESCRIPTION
- Improve documentation based in feedback in #1129.
- Add checks for the legacy Neutrino `options.host` and `options.port`, since they were removed in #852.

Refs:
https://github.com/neutrinojs/neutrino/issues/1129#issuecomment-466825535
https://github.com/neutrinojs/neutrino/issues/1129#issuecomment-467172222
https://github.com/neutrinojs/neutrino/pull/814#issuecomment-466821552