### PR TITLE
docs: Move the quickstart section above manual installation

### DIFF
--- a/packages/airbnb-base/README.md
+++ b/packages/airbnb-base/README.md
@@ -24,7 +24,16 @@ _Note: If you are building a React project, you should probably use
 - webpack 4
 - ESLint 5
 
-## Installation
+## Quickstart
+
+The fastest way to get started is by using the `create-project` scaffolding tool.
+See the [Create new project](https://neutrinojs.org/installation/create-new-project/) docs for more details.
+
+Don’t want to use the CLI helper? No worries, we have you covered with the [manual installation](#manual-installation).
+
+## Manual Installation
+
+First follow the manual installation instructions for your chosen build preset.
 
 `@neutrinojs/airbnb-base` can be installed via the Yarn or npm clients. Inside your project, make sure
 `@neutrinojs/airbnb-base` and `eslint` are development dependencies. You will also be using
@@ -42,15 +51,7 @@ another Neutrino preset for building your application source code.
 ❯ npm install --save-dev @neutrinojs/airbnb-base eslint
 ```
 
-## Project Layout
-
-`@neutrinojs/airbnb-base` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
-means that by default all project source code should live in a directory named `src` in the root of the
-project.
-
-## Quickstart
-
-After adding the Airbnb preset to your Neutrino-built project, edit your project's `.neutrinorc.js` to add the preset for
+After that, edit your project's `.neutrinorc.js` to add the preset for
 linting **before** your build preset. For example, when building your project using `@neutrinojs/web`:
 
 ```js
@@ -113,6 +114,12 @@ error: Missing semicolon (semi) at src/index.js:35:51:
 1 error found.
 1 error potentially fixable with the `--fix` option.
 ```
+
+## Project Layout
+
+`@neutrinojs/airbnb-base` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
+means that by default all project source code should live in a directory named `src` in the root of the
+project.
 
 ## Building
 

--- a/packages/airbnb/README.md
+++ b/packages/airbnb/README.md
@@ -21,7 +21,16 @@ config, following the [Airbnb styleguide](https://github.com/airbnb/javascript).
 - webpack 4
 - ESLint 5
 
-## Installation
+## Quickstart
+
+The fastest way to get started is by using the `create-project` scaffolding tool.
+See the [Create new project](https://neutrinojs.org/installation/create-new-project/) docs for more details.
+
+Don’t want to use the CLI helper? No worries, we have you covered with the [manual installation](#manual-installation).
+
+## Manual Installation
+
+First follow the manual installation instructions for your chosen build preset.
 
 `@neutrinojs/airbnb` can be installed via the Yarn or npm clients. Inside your project, make sure
 `@neutrinojs/airbnb` and `eslint` are development dependencies. You will also be using
@@ -39,15 +48,7 @@ another Neutrino preset for building your application source code.
 ❯ npm install --save-dev @neutrinojs/airbnb eslint
 ```
 
-## Project Layout
-
-`@neutrinojs/airbnb` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
-means that by default all project source code should live in a directory named `src` in the root of the
-project.
-
-## Quickstart
-
-After adding the Airbnb preset to your Neutrino-built project, edit your project's `.neutrinorc.js` to add the preset for
+After that, edit your project's `.neutrinorc.js` to add the preset for
 linting **before** your build preset. For example, when building your project using `@neutrinojs/react`:
 
 ```js
@@ -110,6 +111,12 @@ error: Missing semicolon (semi) at src/index.js:35:51:
 1 error found.
 1 error potentially fixable with the `--fix` option.
 ```
+
+## Project Layout
+
+`@neutrinojs/airbnb` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
+means that by default all project source code should live in a directory named `src` in the root of the
+project.
 
 ## Building
 

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -19,9 +19,18 @@
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino 9 and one of the Neutrino build presets
 - webpack 4
-- Jest 23
+- Jest 24
 
-## Installation
+## Quickstart
+
+The fastest way to get started is by using the `create-project` scaffolding tool.
+See the [Create new project](https://neutrinojs.org/installation/create-new-project/) docs for more details.
+
+Don’t want to use the CLI helper? No worries, we have you covered with the [manual installation](#manual-installation).
+
+## Manual Installation
+
+First follow the manual installation instructions for your chosen build preset.
 
 `@neutrinojs/jest` can be installed via the Yarn or npm clients. Inside your project, make sure
 `@neutrinojs/jest` and `jest` are development dependencies. You will also be using
@@ -60,15 +69,7 @@ higher-level abstraction such as Airbnb's Enzyme. These should be development de
 See the [React's Test Utils documentation](https://reactjs.org/docs/test-utils.html) for specifics on React
 testing with this approach.
 
-## Project Layout
-
-`@neutrinojs/jest` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
-means that by default all project test code should live in a directory named `test` in the root of the
-project. Test files end in either `_test.js`, `.test.js`, `_test.jsx`, or `.test.jsx`.
-
-## Quickstart
-
-After adding the Jest preset to your Neutrino-built project, add a new directory named `test` in the root of the
+After that, add a new directory named `test` in the root of the
 project, with a single JS file named `simple_test.js` in it.
 
 ```bash
@@ -159,6 +160,12 @@ import thingToTest from '../src/thing';
 ```
 
 For more details on specific Jest usage, please refer to their [documentation](https://jestjs.io/).
+
+## Project Layout
+
+`@neutrinojs/jest` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
+means that by default all project test code should live in a directory named `test` in the root of the
+project. Test files end in either `_test.js`, `.test.js`, `_test.jsx`, or `.test.jsx`.
 
 ## Executing single tests
 

--- a/packages/karma/README.md
+++ b/packages/karma/README.md
@@ -19,10 +19,19 @@
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino 9 and one of the Neutrino build presets
 - webpack 4
-- Karma 3 and Karma CLI 1
-- Mocha 5
+- Karma 4 and Karma CLI 2
+- Mocha 6
 
-## Installation
+## Quickstart
+
+The fastest way to get started is by using the `create-project` scaffolding tool.
+See the [Create new project](https://neutrinojs.org/installation/create-new-project/) docs for more details.
+
+Don’t want to use the CLI helper? No worries, we have you covered with the [manual installation](#manual-installation).
+
+## Manual Installation
+
+First follow the manual installation instructions for your chosen build preset.
 
 `@neutrinojs/karma` can be installed via the Yarn or npm clients. Inside your project, make sure
 the dependencies below are installed as development dependencies. You will also be using
@@ -40,15 +49,7 @@ another Neutrino preset for building your application source code.
 ❯ npm install --save-dev @neutrinojs/karma karma karma-cli mocha
 ```
 
-## Project Layout
-
-`@neutrinojs/karma` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
-means that by default all project test code should live in a directory named `test` in the root of the
-project. Test files end in `_test.js` by default.
-
-## Quickstart
-
-After adding the Karma preset to your Neutrino-built project, add a new directory named `test` in the root of the
+After that, add a new directory named `test` in the root of the
 project, with a single JS file named `simple_test.js` in it.
 
 ```bash
@@ -146,6 +147,12 @@ import thingToTest from '../src/thing';
 
 For more details on specific Karma usage, please refer to their
 [documentation](https://karma-runner.github.io/2.0/index.html).
+
+## Project Layout
+
+`@neutrinojs/karma` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
+means that by default all project test code should live in a directory named `test` in the root of the
+project. Test files end in `_test.js` by default.
 
 ## Executing single tests
 

--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -25,43 +25,6 @@
 - webpack 4
 - webpack-cli 3
 
-## Installation
-
-`@neutrinojs/library` can be installed via the Yarn or npm clients. Inside your project, make sure
-that the dependencies below are installed as development dependencies.
-
-#### Yarn
-
-```bash
-❯ yarn add --dev neutrino @neutrinojs/library webpack webpack-cli
-```
-
-#### npm
-
-```bash
-❯ npm install --save-dev neutrino @neutrinojs/library webpack webpack-cli
-```
-
-If you want to have automatically wired sourcemaps added to your project, add `source-map-support`:
-
-#### Yarn
-
-```bash
-❯ yarn add source-map-support
-```
-
-#### npm
-
-```bash
-❯ npm install --save source-map-support
-```
-
-## Project Layout
-
-`@neutrinojs/library` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
-means that by default all library source code should live in a directory named `src` in the root of the
-project. This includes JavaScript files that would be available to your compiled project.
-
 ## Quickstart
 
 The fastest way to get started is by using the `create-project` scaffolding tool.
@@ -96,7 +59,36 @@ for details on all available options.
 
 ### Manual Installation
 
-After installing Neutrino and the Library preset, add a new directory named `src` in the root of the project, with
+`@neutrinojs/library` can be installed via the Yarn or npm clients. Inside your project, make sure
+that the dependencies below are installed as development dependencies.
+
+#### Yarn
+
+```bash
+❯ yarn add --dev neutrino @neutrinojs/library webpack webpack-cli
+```
+
+#### npm
+
+```bash
+❯ npm install --save-dev neutrino @neutrinojs/library webpack webpack-cli
+```
+
+If you want to have automatically wired sourcemaps added to your project, add `source-map-support`:
+
+#### Yarn
+
+```bash
+❯ yarn add source-map-support
+```
+
+#### npm
+
+```bash
+❯ npm install --save source-map-support
+```
+
+After that, add a new directory named `src` in the root of the project, with
 a single JS file named `index.js` in it.
 
 ```bash
@@ -168,6 +160,12 @@ You can now build your library!
 ```bash
 ❯ npm start
 ```
+
+## Project Layout
+
+`@neutrinojs/library` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
+means that by default all library source code should live in a directory named `src` in the root of the
+project. This includes JavaScript files that would be available to your compiled project.
 
 ## Building
 

--- a/packages/mocha/README.md
+++ b/packages/mocha/README.md
@@ -17,9 +17,18 @@
 - Yarn v1.2.1+, or npm v5.4+
 - Neutrino 9 and one of the Neutrino build presets
 - webpack 4
-- Mocha 5
+- Mocha 6
 
-## Installation
+## Quickstart
+
+The fastest way to get started is by using the `create-project` scaffolding tool.
+See the [Create new project](https://neutrinojs.org/installation/create-new-project/) docs for more details.
+
+Don’t want to use the CLI helper? No worries, we have you covered with the [manual installation](#manual-installation).
+
+## Manual Installation
+
+First follow the manual installation instructions for your chosen build preset.
 
 `@neutrinojs/mocha` can be installed via the Yarn or npm clients. Inside your project, make sure
 `@neutrinojs/mocha` and `mocha` are development dependencies. You will also be using
@@ -37,15 +46,7 @@ another Neutrino preset for building your application source code.
 ❯ npm install --save-dev @neutrinojs/mocha mocha
 ```
 
-## Project Layout
-
-`@neutrinojs/mocha` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
-means that by default all project test code should live in a directory named `test` in the root of the
-project. Test files end in `_test.js` by default.
-
-## Quickstart
-
-After adding the Mocha preset to your Neutrino-built project, add a new directory named `test` in the root of the
+After that, add a new directory named `test` in the root of the
 project, with a single JS file named `simple_test.js` in it.
 
 ```bash
@@ -134,6 +135,12 @@ import thingToTest from '../src/thing';
 ```
 
 For more details on specific Mocha usage, please refer to their [documentation](https://mochajs.org/).
+
+## Project Layout
+
+`@neutrinojs/mocha` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
+means that by default all project test code should live in a directory named `test` in the root of the
+project. Test files end in `_test.js` by default.
 
 ## Executing single tests
 

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -24,43 +24,6 @@
 - webpack 4
 - webpack-cli 3
 
-## Installation
-
-`@neutrinojs/node` can be installed via the Yarn or npm clients. Inside your project, make sure
-that the dependencies below are installed as development dependencies.
-
-#### Yarn
-
-```bash
-❯ yarn add --dev neutrino @neutrinojs/node webpack webpack-cli
-```
-
-#### npm
-
-```bash
-❯ npm install --save-dev neutrino @neutrinojs/node webpack webpack-cli
-```
-
-If you want to have automatically wired sourcemaps added to your project, add `source-map-support`:
-
-#### Yarn
-
-```bash
-❯ yarn add source-map-support
-```
-
-#### npm
-
-```bash
-❯ npm install --save source-map-support
-```
-
-## Project Layout
-
-`@neutrinojs/node` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
-means that by default all project source code should live in a directory named `src` in the root of the
-project. This includes JavaScript files that would be available to your compiled project.
-
 ## Quickstart
 
 The fastest way to get started is by using the `create-project` scaffolding tool.
@@ -95,7 +58,36 @@ for details on all available options.
 
 ### Manual Installation
 
-After installing Neutrino and the Node.js preset, add a new directory named `src` in the root of the project, with
+`@neutrinojs/node` can be installed via the Yarn or npm clients. Inside your project, make sure
+that the dependencies below are installed as development dependencies.
+
+#### Yarn
+
+```bash
+❯ yarn add --dev neutrino @neutrinojs/node webpack webpack-cli
+```
+
+#### npm
+
+```bash
+❯ npm install --save-dev neutrino @neutrinojs/node webpack webpack-cli
+```
+
+If you want to have automatically wired sourcemaps added to your project, add `source-map-support`:
+
+#### Yarn
+
+```bash
+❯ yarn add source-map-support
+```
+
+#### npm
+
+```bash
+❯ npm install --save source-map-support
+```
+
+After that, add a new directory named `src` in the root of the project, with
 a single JS file named `index.js` in it.
 
 ```bash
@@ -172,6 +164,12 @@ Server running on port 3000
 ❯ curl http://localhost:3000
 hi!
 ```
+
+## Project Layout
+
+`@neutrinojs/node` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
+means that by default all project source code should live in a directory named `src` in the root of the
+project. This includes JavaScript files that would be available to your compiled project.
 
 ## Building
 

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -32,48 +32,6 @@
 - webpack-cli 3
 - webpack-dev-server 3
 
-## Installation
-
-`@neutrinojs/preact` can be installed via the Yarn or npm clients. Inside your project, make sure
-that the Neutrino and webpack related dependencies below are installed as development dependencies.
-You will also need `preact` for actual Preact development.
-
-#### Yarn
-
-```bash
-❯ yarn add --dev neutrino @neutrinojs/preact webpack webpack-cli webpack-dev-server
-❯ yarn add preact
-```
-
-#### npm
-
-```bash
-❯ npm install --save-dev neutrino @neutrinojs/preact webpack webpack-cli webpack-dev-server
-❯ npm install --save preact
-```
-
-If you want to import React-based modules or packages, you should also install the `preact-compat`
-compatibility layer:
-
-#### Yarn
-
-```bash
-❯ yarn add preact-compat
-```
-
-#### npm
-
-```bash
-❯ npm install --save preact-compat
-```
-
-## Project Layout
-
-`@neutrinojs/preact` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
-means that by default all project source code should live in a directory named `src` in the root of the
-project. This includes JavaScript files, CSS stylesheets, images, and any other assets that would be available
-to import your compiled project.
-
 ## Quickstart
 
 The fastest way to get started is by using the `create-project` scaffolding tool.
@@ -108,7 +66,40 @@ for details on all available options.
 
 ### Manual Installation
 
-After installing Neutrino and the Preact preset, add a new directory named `src` in the root of the project, with
+`@neutrinojs/preact` can be installed via the Yarn or npm clients. Inside your project, make sure
+that the Neutrino and webpack related dependencies below are installed as development dependencies.
+You will also need `preact` for actual Preact development.
+
+#### Yarn
+
+```bash
+❯ yarn add --dev neutrino @neutrinojs/preact webpack webpack-cli webpack-dev-server
+❯ yarn add preact
+```
+
+#### npm
+
+```bash
+❯ npm install --save-dev neutrino @neutrinojs/preact webpack webpack-cli webpack-dev-server
+❯ npm install --save preact
+```
+
+If you want to import React-based modules or packages, you should also install the `preact-compat`
+compatibility layer:
+
+#### Yarn
+
+```bash
+❯ yarn add preact-compat
+```
+
+#### npm
+
+```bash
+❯ npm install --save preact-compat
+```
+
+After that, add a new directory named `src` in the root of the project, with
 a single JS file named `index.js` in it.
 
 ```bash
@@ -166,6 +157,13 @@ Start the app, then open a browser to the address in the console:
 ```bash
 ❯ npm start
 ```
+
+## Project Layout
+
+`@neutrinojs/preact` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
+means that by default all project source code should live in a directory named `src` in the root of the
+project. This includes JavaScript files, CSS stylesheets, images, and any other assets that would be available
+to import your compiled project.
 
 ## Building
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -38,7 +38,38 @@ polyfills in your library code, consider importing @babel/polyfill, core-js, or 
 - webpack-cli 3
 - webpack-dev-server 3
 
-## Installation
+## Quickstart
+
+The fastest way to get started is by using the `create-project` scaffolding tool.
+Don’t want to use the CLI helper? No worries, we have you covered with the [manual installation](#manual-installation).
+
+### create-project
+
+Run the following command to start the process. Substitute `<directory-name>` with the directory name you wish to create
+for this project.
+
+#### Yarn
+
+```
+❯ yarn create @neutrinojs/project <directory-name>
+```
+
+_Note: The `create` command is a shorthand that helps you do two things at once. See the [Yarn create docs](https://yarnpkg.com/lang/en/docs/cli/create/) for more details._
+
+#### npm/npx
+
+[`npx`](https://github.com/zkat/npx) comes pre-installed with `npm`. If you’re running an older version of `npm`, then
+`npm install -g npm` to update to the latest version.
+
+```
+❯ npx @neutrinojs/create-project <directory-name>
+```
+
+The CLI helper will prompt for the project to scaffold, and will offer to set
+up a test runner as well as linting to your project. Refer to the [Create new project](https://neutrinojs.org/installation/create-new-project/) section
+for details on all available options.
+
+### Manual Installation
 
 `@neutrinojs/react-components` can be installed via the Yarn or npm clients. Inside your project, make sure
 that the Neutrino and webpack related dependencies below are installed as development dependencies.
@@ -80,48 +111,7 @@ this error, you will need to add a
 You can do this from your `.neutrinorc.js` file if using a Neutrino-based linting preset,
 or your `.eslintrc.js` file for other ESLint-ing mechanisms.**
 
-## Project Layout
-
-`@neutrinojs/react-components` follows the standard [project layout](https://neutrinojs.org/project-layout/)
-specified by Neutrino. This means that by default all project source code should live in a directory named `src` in the
-root of the project. This includes JavaScript files that would be available to your compiled project.
-
-All components should be their own module within a directory named `components` inside the source directory.
-
-## Quickstart
-
-The fastest way to get started is by using the `create-project` scaffolding tool.
-Don’t want to use the CLI helper? No worries, we have you covered with the [manual installation](#manual-installation).
-
-### create-project
-
-Run the following command to start the process. Substitute `<directory-name>` with the directory name you wish to create
-for this project.
-
-#### Yarn
-
-```
-❯ yarn create @neutrinojs/project <directory-name>
-```
-
-_Note: The `create` command is a shorthand that helps you do two things at once. See the [Yarn create docs](https://yarnpkg.com/lang/en/docs/cli/create/) for more details._
-
-#### npm/npx
-
-[`npx`](https://github.com/zkat/npx) comes pre-installed with `npm`. If you’re running an older version of `npm`, then
-`npm install -g npm` to update to the latest version.
-
-```
-❯ npx @neutrinojs/create-project <directory-name>
-```
-
-The CLI helper will prompt for the project to scaffold, and will offer to set
-up a test runner as well as linting to your project. Refer to the [Create new project](https://neutrinojs.org/installation/create-new-project/) section
-for details on all available options.
-
-### Manual Installation
-
-After installing Neutrino and this preset, add a new directory named `src` in the root of the project, with
+After that, add a new directory named `src` in the root of the project, with
 a single JS file named `index.js` in it. This `index` file can be used to render any components you
 wish to the browser to preview and.
 
@@ -191,6 +181,14 @@ Start the app, then open a browser to the address in the console to preview your
 ```bash
 ❯ npm start
 ```
+
+## Project Layout
+
+`@neutrinojs/react-components` follows the standard [project layout](https://neutrinojs.org/project-layout/)
+specified by Neutrino. This means that by default all project source code should live in a directory named `src` in the
+root of the project. This includes JavaScript files that would be available to your compiled project.
+
+All components should be their own module within a directory named `components` inside the source directory.
 
 ## Building
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -32,33 +32,6 @@
 - webpack-cli 3
 - webpack-dev-server 3
 
-## Installation
-
-`@neutrinojs/react` can be installed via the Yarn or npm clients. Inside your project, make sure
-that the Neutrino and webpack related dependencies below are installed as development dependencies.
-You will also need React and React DOM for actual React development.
-
-#### Yarn
-
-```bash
-❯ yarn add --dev neutrino @neutrinojs/react webpack webpack-cli webpack-dev-server
-❯ yarn add react react-dom
-```
-
-#### npm
-
-```bash
-❯ npm install --save-dev neutrino @neutrinojs/react webpack webpack-cli webpack-dev-server
-❯ npm install --save react react-dom
-```
-
-## Project Layout
-
-`@neutrinojs/react` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
-means that by default all project source code should live in a directory named `src` in the root of the
-project. This includes JavaScript files, CSS stylesheets, images, and any other assets that would be available
-to import your compiled project.
-
 ## Quickstart
 
 The fastest way to get started is by using the `create-project` scaffolding tool.
@@ -93,7 +66,25 @@ for details on all available options.
 
 ### Manual Installation
 
-After installing Neutrino and the React preset, add a new directory named `src` in the root of the project, with
+`@neutrinojs/react` can be installed via the Yarn or npm clients. Inside your project, make sure
+that the Neutrino and webpack related dependencies below are installed as development dependencies.
+You will also need React and React DOM for actual React development.
+
+#### Yarn
+
+```bash
+❯ yarn add --dev neutrino @neutrinojs/react webpack webpack-cli webpack-dev-server
+❯ yarn add react react-dom
+```
+
+#### npm
+
+```bash
+❯ npm install --save-dev neutrino @neutrinojs/react webpack webpack-cli webpack-dev-server
+❯ npm install --save react react-dom
+```
+
+After that, add a new directory named `src` in the root of the project, with
 a single JS file named `index.js` in it.
 
 ```bash
@@ -151,6 +142,13 @@ Start the app, then open a browser to the address in the console:
 ```bash
 ❯ npm start
 ```
+
+## Project Layout
+
+`@neutrinojs/react` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
+means that by default all project source code should live in a directory named `src` in the root of the
+project. This includes JavaScript files, CSS stylesheets, images, and any other assets that would be available
+to import your compiled project.
 
 ## Building
 

--- a/packages/standardjs/README.md
+++ b/packages/standardjs/README.md
@@ -21,7 +21,16 @@
 - webpack 4
 - ESLint 5
 
-## Installation
+## Quickstart
+
+The fastest way to get started is by using the `create-project` scaffolding tool.
+See the [Create new project](https://neutrinojs.org/installation/create-new-project/) docs for more details.
+
+Don’t want to use the CLI helper? No worries, we have you covered with the [manual installation](#manual-installation).
+
+## Manual Installation
+
+First follow the manual installation instructions for your chosen build preset.
 
 `@neutrinojs/standardjs` can be installed via the Yarn or npm clients. Inside your project, make sure
 `@neutrinojs/standardjs` and `eslint` are development dependencies. You will also be using
@@ -39,15 +48,7 @@ another Neutrino preset for building your application source code.
 ❯ npm install --save-dev @neutrinojs/standardjs eslint
 ```
 
-## Project Layout
-
-`@neutrinojs/standardjs` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
-means that by default all project source code should live in a directory named `src` in the root of the
-project.
-
-## Quickstart
-
-After adding the StandardJS preset to your Neutrino-built project, edit your project's `.neutrinorc.js` to add the preset for
+After that, edit your project's `.neutrinorc.js` to add the preset for
 linting **before** your build preset. For example, when building your project using `@neutrinojs/web`:
 
 ```js
@@ -110,6 +111,12 @@ error: Missing semicolon (semi) at src/index.js:35:51:
 1 error found.
 1 error potentially fixable with the `--fix` option.
 ```
+
+## Project Layout
+
+`@neutrinojs/standardjs` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
+means that by default all project source code should live in a directory named `src` in the root of the
+project.
 
 ## Building
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -28,33 +28,6 @@
 - webpack-cli 3
 - webpack-dev-server 3
 
-## Installation
-
-`@neutrinojs/vue` can be installed via the Yarn or npm clients. Inside your project, make sure
-that the Neutrino and webpack related dependencies below are installed as development dependencies.
-You will also need Vue for actual Vue development.
-
-#### Yarn
-
-```bash
-❯ yarn add --dev neutrino @neutrinojs/vue webpack webpack-cli webpack-dev-server
-❯ yarn add vue
-```
-
-#### npm
-
-```bash
-❯ npm install --save-dev neutrino @neutrinojs/vue webpack webpack-cli webpack-dev-server
-❯ npm install --save vue
-```
-
-## Project Layout
-
-`@neutrinojs/vue` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
-means that by default all project source code should live in a directory named `src` in the root of the
-project. This includes JavaScript files, CSS stylesheets, images, and any other assets that would be available
-to import your compiled project.
-
 ## Quickstart
 
 The fastest way to get started is by using the `create-project` scaffolding tool.
@@ -89,7 +62,25 @@ for details on all available options.
 
 ### Manual Installation
 
-After installing Neutrino and the Vue preset, add a new directory named `src` in the root of the project, with
+`@neutrinojs/vue` can be installed via the Yarn or npm clients. Inside your project, make sure
+that the Neutrino and webpack related dependencies below are installed as development dependencies.
+You will also need Vue for actual Vue development.
+
+#### Yarn
+
+```bash
+❯ yarn add --dev neutrino @neutrinojs/vue webpack webpack-cli webpack-dev-server
+❯ yarn add vue
+```
+
+#### npm
+
+```bash
+❯ npm install --save-dev neutrino @neutrinojs/vue webpack webpack-cli webpack-dev-server
+❯ npm install --save vue
+```
+
+After that, add a new directory named `src` in the root of the project, with
 two files `index.js` and `App.vue` in it.
 
 ```bash
@@ -170,6 +161,13 @@ Start the app, then open a browser to the address in the console:
 ```bash
 ❯ npm start
 ```
+
+## Project Layout
+
+`@neutrinojs/vue` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
+means that by default all project source code should live in a directory named `src` in the root of the
+project. This includes JavaScript files, CSS stylesheets, images, and any other assets that would be available
+to import your compiled project.
 
 ## Building
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -28,30 +28,6 @@
 - webpack-cli 3
 - webpack-dev-server 3
 
-## Installation
-
-`@neutrinojs/web` can be installed via the Yarn or npm clients. Inside your project, make sure
-that the dependencies below are installed as development dependencies.
-
-#### Yarn
-
-```bash
-❯ yarn add --dev neutrino @neutrinojs/web webpack webpack-cli webpack-dev-server
-```
-
-#### npm
-
-```bash
-❯ npm install --save-dev neutrino @neutrinojs/web webpack webpack-cli webpack-dev-server
-```
-
-## Project Layout
-
-`@neutrinojs/web` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
-means that by default all project source code should live in a directory named `src` in the root of the
-project. This includes JavaScript files, CSS stylesheets, images, and any other assets that would be available
-to your compiled project.
-
 ## Quickstart
 
 The fastest way to get started is by using the `create-project` scaffolding tool.
@@ -86,7 +62,22 @@ for details on all available options.
 
 ### Manual Installation
 
-After installing Neutrino and the Web preset, add a new directory named `src` in the root of the project, with
+`@neutrinojs/web` can be installed via the Yarn or npm clients. Inside your project, make sure
+that the dependencies below are installed as development dependencies.
+
+#### Yarn
+
+```bash
+❯ yarn add --dev neutrino @neutrinojs/web webpack webpack-cli webpack-dev-server
+```
+
+#### npm
+
+```bash
+❯ npm install --save-dev neutrino @neutrinojs/web webpack webpack-cli webpack-dev-server
+```
+
+After that, add a new directory named `src` in the root of the project, with
 a single JS file named `index.js` in it.
 
 ```bash
@@ -146,6 +137,13 @@ Start the app, then open a browser to the address in the console:
 ```bash
 ❯ npm start
 ```
+
+## Project Layout
+
+`@neutrinojs/web` follows the standard [project layout](https://neutrinojs.org/project-layout/) specified by Neutrino. This
+means that by default all project source code should live in a directory named `src` in the root of the
+project. This includes JavaScript files, CSS stylesheets, images, and any other assets that would be available
+to your compiled project.
 
 ## Building
 


### PR DESCRIPTION
Since for most users it will be the easiest way to get started.

Fixes #644.