### PR TITLE
[v8.x] Docs: create-new-project grammar fix

### DIFF
--- a/docs/installation/create-new-project.md
+++ b/docs/installation/create-new-project.md
@@ -1,7 +1,7 @@
 # Scaffold a Neutrino Project
 
 Neutrino can help you quickly start new projects by scaffolding your initial project structure.
-`@neutrinojs/create-project` uses middleware and presets behind the scene to build projects. If you are not
+`@neutrinojs/create-project` uses middleware and presets behind the scenes to build projects. If you are not
 familiar with them, take a moment to explore [middleware](../middleware/README.md)
 and [presets](../presets/README.md).
 


### PR DESCRIPTION
"behind the scenes" phraseology was missing an ending s in the current version
the ending s was added in the proposed version to render the phraseology as "behind the scenes" correcting the previous "behind the scene".