### PR TITLE
Fix generation of changelog during release:prepare

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -176,11 +176,12 @@ the latest changes from the master branch.
 
     `sed -i 's/"neutrino": "^9.0.0-0"/"neutrino": "^9.0.0-rc.0"/g' packages/*/package.json`
 
-5. Commit the changes using: `git commit -a -m 'vN.N.N'`
+5. Commit the changes using: `yarn release:commit`
 
-    If the release warrants having a longer description included in the changelog,
-    one can be provided by additionally passing `-e` to provide a multi-line commit
-    message that  `auto-changelog` will automatically add to `CHANGELOG.md`.
+    Your editor will open, where a multi-line commit message can be entered if you would
+    like the release to have a summary in the changelog above the list of commits. If a
+    summary is provided, the changelog will then need to be re-generated after the commit
+    (using `yarn changelog`) and then the commit amended to include the changes.
 
 6. Open a Pull Request and request review.
 7. Once the Pull request is merged, check out `master` at that revision.
@@ -188,5 +189,7 @@ the latest changes from the master branch.
     (It's important to not publish from the PR's branch, since with squash and
     merge the resultant package revision SHA will be different.)
 
-8. Git tag and push the new tag: `git tag vN.N.N && git push upstream vN.N.N`
-9. Publish to NPM: `yarn release:publish` (or for a pre-release, `yarn release:publish-next`)
+8. Git tag and push the new tag: `yarn release:tag`
+9. Double check the tagged commit (and its changelog) looks as expected on GitHub
+   (it's a lot easier to fix at this stage than after publishing ).
+10. Publish to NPM: `yarn release:publish` (or for a pre-release, `yarn release:publish-next`)

--- a/package.json
+++ b/package.json
@@ -15,16 +15,20 @@
     "packages/*"
   ],
   "scripts": {
+    "changelog": "auto-changelog --latest-version $(yarn -s print-version)",
     "docs:bootstrap": "pip install -r docs/requirements.txt",
     "docs:serve": "mkdocs serve",
     "link:all": "lerna exec yarn link",
     "lint": "eslint --no-eslintrc --c ./.eslintrc.js --cache --report-unused-disable-directives --format codeframe --ext js,jsx .",
     "prettier:check": "prettier --ignore-path .eslintignore --check \"**/*.{css,html,js,jsx,json,md,yaml,yml}\"",
     "prettier:fix": "prettier --ignore-path .eslintignore --write \"**/*.{css,html,js,jsx,json,md,yaml,yml}\"",
-    "release:prepare": "lerna version",
+    "print-version": "jq -r .version lerna.json",
+    "release:prepare": "lerna version && prettier --write lerna.json",
+    "release:commit": "git commit --all --message v$(yarn -s print-version) --edit",
+    "release:tag": "git tag v$(yarn -s print-version) && git push upstream v$(yarn -s print-version)",
     "release:publish": "lerna publish from-package",
     "release:publish-next": "yarn release:publish --dist-tag next",
-    "release:ci": "SKIP_CHANGELOG=true lerna publish preminor --registry http://localhost:4873 --no-git-reset --yes",
+    "release:ci": "lerna publish preminor --registry http://localhost:4873 --no-git-reset --yes",
     "test": "ava --fail-fast packages/*/test \"!packages/create-project/test\"",
     "test:create-project": "ava --verbose packages/create-project/test",
     "validate:eslintrc:root": "eslint --no-eslintrc --print-config . -c ./.eslintrc.js > /dev/null",
@@ -33,7 +37,7 @@
     "validate:eslintrc:airbnb-base": "eslint --no-eslintrc --print-config . -c ./packages/airbnb-base/eslintrc.js > /dev/null",
     "validate:eslintrc:standardjs": "eslint --no-eslintrc --print-config . -c ./packages/standardjs/eslintrc.js > /dev/null",
     "validate:eslintrc": "yarn validate:eslintrc:eslint && yarn validate:eslintrc:airbnb-base && yarn validate:eslintrc:airbnb && yarn validate:eslintrc:standardjs && yarn validate:eslintrc:root",
-    "version": "[[ -z \"$SKIP_CHANGELOG\" ]] && (auto-changelog --package && git add CHANGELOG.md) || echo 'Skipping changelog.'"
+    "version": "yarn changelog"
   },
   "devDependencies": {
     "auto-changelog": "^1.11.0",


### PR DESCRIPTION
Previously we were using auto-changelog's `--package` option, which does not work with Lerna monorepos, since there is no version in the repo root `package.json`. Now the version is instead read from `lerna.json`.

In addition, `SKIP_CHANGELOG` has been removed, since:
(a) using environment variables in package.json scripts makes them incompatible with Windows
(b) we now use the `--no-git-reset` option with `release:ci`, so the working directory will be dirty regardless, so it's fine to modify the changelog too (and it means changelog generation has CI coverage)

Finally, some of the other release process steps have been converted to package.json scripts to simplify the steps.

Fixes #762.