### PR TITLE
Further tweaks to the release process

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -165,7 +165,7 @@ the latest changes from the master branch.
 1. Decide whether the new version should be a major/minor/patch/prerelease version bump.
 2. From the root of the Neutrino repository, run:
 
-    `git fetch upstream --quiet && git checkout -b version-bump upstream/master`
+    `git fetch upstream --quiet && git checkout --no-track -b version-bump upstream/master`
 
 3. Then run `yarn release:prepare` and pick the desired new version.
 4. Check the changes in the working directory and adjust if necessary.
@@ -174,7 +174,12 @@ the latest changes from the master branch.
     you will want to manually increase the presets' version of `neutrino` in
     `peerDependencies`. For example by running:
 
-    `sed -i 's/"neutrino": "^9.0.0-0"/"neutrino": "^9.0.0-rc.0"/g' packages/*/package.json`
+    `sed -i 's/"neutrino": "^9.0.0"/"neutrino": "^10.0.0"/g' packages/*/package.json`
+
+    On OS X, you will need to add an additional set of quotes after the `-i`, ie:
+    `sed -i '' 's/....'`. For Neutrino pre-releases you will likely want to remove
+    the caret and pin to an exact version, since breaking changes can occur with
+    each release.
 
 5. Commit the changes using: `yarn release:commit`
 

--- a/package.json
+++ b/package.json
@@ -15,17 +15,17 @@
     "packages/*"
   ],
   "scripts": {
-    "changelog": "auto-changelog --latest-version $(yarn -s print-version)",
+    "changelog": "auto-changelog --package lerna.json",
     "docs:bootstrap": "pip install -r docs/requirements.txt",
     "docs:serve": "mkdocs serve",
     "link:all": "lerna exec yarn link",
     "lint": "eslint --no-eslintrc --c ./.eslintrc.js --cache --report-unused-disable-directives --format codeframe --ext js,jsx .",
     "prettier:check": "prettier --ignore-path .eslintignore --check \"**/*.{css,html,js,jsx,json,md,yaml,yml}\"",
     "prettier:fix": "prettier --ignore-path .eslintignore --write \"**/*.{css,html,js,jsx,json,md,yaml,yml}\"",
-    "print-version": "jq -r .version lerna.json",
-    "release:prepare": "lerna version && prettier --write lerna.json",
-    "release:commit": "git commit --all --message v$(yarn -s print-version) --edit",
-    "release:tag": "git tag v$(yarn -s print-version) && git push upstream v$(yarn -s print-version)",
+    "print-version": "jq -r '\"v\" + .version' lerna.json",
+    "release:prepare": "lerna version && prettier --write lerna.json && yarn changelog",
+    "release:commit": "git commit --all --message $(yarn -s print-version) --edit",
+    "release:tag": "git tag $(yarn -s print-version) && git push upstream $(yarn -s print-version)",
     "release:publish": "lerna publish from-package",
     "release:publish-next": "yarn release:publish --dist-tag next",
     "release:ci": "lerna publish preminor --registry http://localhost:4873 --no-git-reset --yes",
@@ -36,11 +36,10 @@
     "validate:eslintrc:airbnb": "eslint --no-eslintrc --print-config . -c ./packages/airbnb/eslintrc.js > /dev/null",
     "validate:eslintrc:airbnb-base": "eslint --no-eslintrc --print-config . -c ./packages/airbnb-base/eslintrc.js > /dev/null",
     "validate:eslintrc:standardjs": "eslint --no-eslintrc --print-config . -c ./packages/standardjs/eslintrc.js > /dev/null",
-    "validate:eslintrc": "yarn validate:eslintrc:eslint && yarn validate:eslintrc:airbnb-base && yarn validate:eslintrc:airbnb && yarn validate:eslintrc:standardjs && yarn validate:eslintrc:root",
-    "version": "yarn changelog"
+    "validate:eslintrc": "yarn validate:eslintrc:eslint && yarn validate:eslintrc:airbnb-base && yarn validate:eslintrc:airbnb && yarn validate:eslintrc:standardjs && yarn validate:eslintrc:root"
   },
   "devDependencies": {
-    "auto-changelog": "^1.12.1",
+    "auto-changelog": "^1.13.0",
     "ava": "^1.4.1",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2366,10 +2366,10 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-auto-changelog@^1.12.1:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/auto-changelog/-/auto-changelog-1.12.1.tgz#7d7e40fc370bd4c17d51999fe68c3c97dd3d7428"
-  integrity sha512-whOLB6cm8QqgK4MWP1lZL578mSy3aw9h+Xkm81lyjOATBn4helSLaWXAuamo3m/Uyy88qlnHVfdXp0E7UgLszg==
+auto-changelog@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/auto-changelog/-/auto-changelog-1.13.0.tgz#d082444d1ae9411e4ab83b6e82ed0fcb95f7d471"
+  integrity sha512-djreNOUH6i09Lkm/A3oDApJjSrphUb8dxnyCan8CVEN1uHrD02NlraZic9VdPu37ZYcf1lqYNLjuwT5CFZxtPw==
   dependencies:
     "@babel/polyfill" "^7.4.3"
     commander "^2.20.0"


### PR DESCRIPTION
* Call `yarn changelog` from `release:prepare` rather than during the `version` lifecycle, since `lerna.json` isn't always written by that point.
* Add missing "v" prefix to the changelog version number, and switch to using auto-changelog 1.13.0's new `--package <file>` support, so the changelog command doesn't need to use bash command substitution and so is compatible with Windows.
* Add `--no-track` to the Git checkout command, so that the new branch doesn't automatically track master (which means pushes end up on the wrong branch).
* Mention how to adjust the sed command for it to work on OS X.