### PR TITLE
Coerce version before parsing major

### DIFF
--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -40,7 +40,8 @@ module.exports = (opts = {}) => {
       neutrino.options.packageJson || {};
     const corejs =
       ('core-js' in dependencies || 'core-js' in devDependencies) &&
-      semver.major(dependencies['core-js'] || devDependencies['core-js']);
+      semver.coerce(dependencies['core-js'] || devDependencies['core-js'])
+        .major;
 
     Object.assign(options, {
       babel: babelMerge(

--- a/packages/library/index.js
+++ b/packages/library/index.js
@@ -4,7 +4,6 @@ const clean = require('@neutrinojs/clean');
 const babelMerge = require('babel-merge');
 const merge = require('deepmerge');
 const nodeExternals = require('webpack-node-externals');
-const semver = require('semver');
 const { ConfigurationError } = require('neutrino/errors');
 
 module.exports = (opts = {}) => {
@@ -36,12 +35,7 @@ module.exports = (opts = {}) => {
       Object.assign(options, { targets: {} });
     }
 
-    const { dependencies = {}, devDependencies = {} } =
-      neutrino.options.packageJson || {};
-    const corejs =
-      ('core-js' in dependencies || 'core-js' in devDependencies) &&
-      semver.coerce(dependencies['core-js'] || devDependencies['core-js'])
-        .major;
+    const coreJsVersion = neutrino.getDependencyVersion('core-js');
 
     Object.assign(options, {
       babel: babelMerge(
@@ -52,9 +46,9 @@ module.exports = (opts = {}) => {
               require.resolve('@babel/preset-env'),
               {
                 debug: neutrino.options.debug,
-                useBuiltIns: corejs ? 'entry' : false,
+                useBuiltIns: coreJsVersion ? 'entry' : false,
                 targets: options.targets,
-                ...(corejs && { corejs }),
+                ...(coreJsVersion && { corejs: coreJsVersion.major }),
               },
             ],
           ],

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -38,7 +38,6 @@
     "@neutrinojs/compile-loader": "9.0.0-rc.1",
     "babel-merge": "^2.0.1",
     "deepmerge": "^1.5.2",
-    "semver": "^6.0.0",
     "webpack-node-externals": "^1.7.2"
   },
   "peerDependencies": {

--- a/packages/neutrino/Neutrino.js
+++ b/packages/neutrino/Neutrino.js
@@ -1,5 +1,6 @@
 const clone = require('lodash.clonedeep');
 const Config = require('webpack-chain');
+const semver = require('semver');
 const { isAbsolute, join } = require('path');
 const { ConfigurationError } = require('./errors');
 const { source } = require('./extensions');
@@ -147,6 +148,16 @@ module.exports = class Neutrino {
       extensions.length === 1
         ? String.raw`\.${exts[0]}$`
         : String.raw`\.(${exts.join('|')})$`,
+    );
+  }
+
+  getDependencyVersion(dependency) {
+    const { dependencies = {}, devDependencies = {} } =
+      this.options.packageJson || {};
+
+    return (
+      (dependency in dependencies || dependency in devDependencies) &&
+      semver.coerce(dependencies[dependency] || devDependencies[dependency])
     );
   }
 

--- a/packages/neutrino/package.json
+++ b/packages/neutrino/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
+    "semver": "^6.0.0",
     "webpack-chain": "^5.2.4",
     "yargs-parser": "^13.0.0"
   }

--- a/packages/neutrino/test/api_test.js
+++ b/packages/neutrino/test/api_test.js
@@ -227,3 +227,20 @@ test('regexFromExtensions', t => {
     '/\\.(worker\\.js|worker\\.jsx)$/',
   );
 });
+
+test('getDependencyVersion', t => {
+  const api = new Neutrino();
+
+  api.options.packageJson = {
+    devDependencies: {
+      neutrino: '^9',
+    },
+    dependencies: {
+      'core-js': '^3',
+    },
+  };
+
+  t.is(api.getDependencyVersion('neutrino').major, 9);
+  t.is(api.getDependencyVersion('core-js').major, 3);
+  t.is(api.getDependencyVersion('eslint'), false);
+});

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -7,7 +7,6 @@ const nodeExternals = require('webpack-node-externals');
 const { basename, parse, format } = require('path');
 const merge = require('deepmerge');
 const omit = require('lodash.omit');
-const semver = require('semver');
 const { ConfigurationError } = require('neutrino/errors');
 
 const getOutputForEntry = entry =>
@@ -38,12 +37,7 @@ module.exports = (opts = {}) => {
       },
       opts,
     );
-    const { dependencies = {}, devDependencies = {} } =
-      neutrino.options.packageJson || {};
-    const corejs =
-      ('core-js' in dependencies || 'core-js' in devDependencies) &&
-      semver.coerce(dependencies['core-js'] || devDependencies['core-js'])
-        .major;
+    const coreJsVersion = neutrino.getDependencyVersion('core-js');
 
     neutrino.use(
       compileLoader({
@@ -57,8 +51,8 @@ module.exports = (opts = {}) => {
                 {
                   debug: neutrino.options.debug,
                   targets: options.targets,
-                  useBuiltIns: corejs ? 'entry' : false,
-                  ...(corejs && { corejs }),
+                  useBuiltIns: coreJsVersion ? 'entry' : false,
+                  ...(coreJsVersion && { corejs: coreJsVersion.major }),
                 },
               ],
             ],

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -42,7 +42,8 @@ module.exports = (opts = {}) => {
       neutrino.options.packageJson || {};
     const corejs =
       ('core-js' in dependencies || 'core-js' in devDependencies) &&
-      semver.major(dependencies['core-js'] || devDependencies['core-js']);
+      semver.coerce(dependencies['core-js'] || devDependencies['core-js'])
+        .major;
 
     neutrino.use(
       compileLoader({

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -33,7 +33,6 @@
     "babel-merge": "^2.0.1",
     "deepmerge": "^1.5.2",
     "lodash.omit": "^4.5.0",
-    "semver": "^6.0.0",
     "webpack-node-externals": "^1.7.2"
   },
   "peerDependencies": {

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -132,7 +132,7 @@ module.exports = (opts = {}) => neutrino => {
     neutrino.options.packageJson || {};
   const corejs =
     ('core-js' in dependencies || 'core-js' in devDependencies) &&
-    semver.major(dependencies['core-js'] || devDependencies['core-js']);
+    semver.coerce(dependencies['core-js'] || devDependencies['core-js']).major;
 
   Object.assign(options, {
     babel: babelMerge(

--- a/packages/web/index.js
+++ b/packages/web/index.js
@@ -8,7 +8,6 @@ const clean = require('@neutrinojs/clean');
 const devServer = require('@neutrinojs/dev-server');
 const babelMerge = require('babel-merge');
 const merge = require('deepmerge');
-const semver = require('semver');
 const { ConfigurationError } = require('neutrino/errors');
 
 module.exports = (opts = {}) => neutrino => {
@@ -128,11 +127,7 @@ module.exports = (opts = {}) => neutrino => {
     ];
   }
 
-  const { dependencies = {}, devDependencies = {} } =
-    neutrino.options.packageJson || {};
-  const corejs =
-    ('core-js' in dependencies || 'core-js' in devDependencies) &&
-    semver.coerce(dependencies['core-js'] || devDependencies['core-js']).major;
+  const coreJsVersion = neutrino.getDependencyVersion('core-js');
 
   Object.assign(options, {
     babel: babelMerge(
@@ -143,9 +138,9 @@ module.exports = (opts = {}) => neutrino => {
             require.resolve('@babel/preset-env'),
             {
               debug: neutrino.options.debug,
-              useBuiltIns: corejs ? 'entry' : false,
+              useBuiltIns: coreJsVersion ? 'entry' : false,
               targets: options.targets,
-              ...(corejs && { corejs }),
+              ...(coreJsVersion && { corejs: coreJsVersion.major }),
             },
           ],
         ],

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -35,8 +35,7 @@
     "@neutrinojs/image-loader": "9.0.0-rc.1",
     "@neutrinojs/style-loader": "9.0.0-rc.1",
     "babel-merge": "^2.0.1",
-    "deepmerge": "^1.5.2",
-    "semver": "^6.0.0"
+    "deepmerge": "^1.5.2"
   },
   "peerDependencies": {
     "neutrino": "9.0.0-rc.1",


### PR DESCRIPTION
With #1366, errors will occur package.json does not contain a fully qualified range (e.g `'3'`, `'^3'`).

> TypeError: Invalid Version: 3

> TypeError: Invalid Version: ^3

Doing `semver.coerce` first seems to fix this.

Fixes #1367.
Fixes #1370.