### PR TITLE
create-project: Define peerDependencies in react-components projects

### DIFF
--- a/packages/create-project/commands/init/constants.js
+++ b/packages/create-project/commands/init/constants.js
@@ -39,9 +39,12 @@ const KARMA_CLI = 'karma-cli@^2';
 const MOCHA = 'mocha@^6';
 const PREACT = 'preact@^8';
 const PREACT_COMPAT = 'preact-compat@^3';
-const PROP_TYPES = 'prop-types@^15';
-const REACT = 'react@^16';
-const REACT_DOM = 'react-dom@^16';
+const PROP_TYPES_VERSION = '^15';
+const PROP_TYPES = `prop-types@${PROP_TYPES_VERSION}`;
+const REACT_VERSION = '^16';
+const REACT = `react@${REACT_VERSION}`;
+const REACT_DOM_VERSION = '^16';
+const REACT_DOM = `react-dom@${REACT_DOM_VERSION}`;
 const REACT_HOT_LOADER = 'react-hot-loader@^4';
 const VUE = 'vue@^2';
 const WEBPACK = 'webpack@^4';
@@ -183,6 +186,13 @@ const webapp = name => ({
         WEBPACK_CLI,
         WEBPACK_DEV_SERVER,
       ],
+      // peerDependencies are copied directly to package.json so must be an object,
+      // unlike dependencies and devDependencies which are passed to npm/yarn instead.
+      peerDependencies: {
+        'prop-types': PROP_TYPES_VERSION,
+        react: REACT_VERSION,
+        'react-dom': REACT_DOM_VERSION,
+      },
       scripts: {
         start: DEV_SERVER_START,
         build: BUILD,

--- a/packages/create-project/test/cli_test.js
+++ b/packages/create-project/test/cli_test.js
@@ -33,7 +33,7 @@ const tests = [
   },
   {
     project: presets.get(N.REACT_COMPONENTS),
-    linter: presets.get(N.STANDARDJS),
+    linter: presets.get(N.AIRBNB),
   },
   {
     project: presets.get(N.WEB_NODE_LIBRARY),

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -117,14 +117,6 @@ If you want to have automatically wired sourcemaps added to your project, add
 ❯ npm install --save source-map-support
 ```
 
-**NOTE: If you use this preset along with eslint-plugin-import, including
-`@neutrinojs/airbnb` or Airbnb's ESLint configurations, you will experience
-linting errors for having `react` and `react-dom` installed in
-`devDependencies`. To overcome this error, you will need to add a
-[linting rule override](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md).
-You can do this from your `.neutrinorc.js` file if using a Neutrino-based
-linting preset, or your `.eslintrc.js` file for other ESLint-ing mechanisms.**
-
 After that, add a new directory named `src` in the root of the project, with a
 single JS file named `index.js` in it. This `index` file can be used to render
 any components you wish to the browser to preview and.


### PR DESCRIPTION
For React components projects, it's expected that they will not have a direct dependency on React/React DOM/prop-types, but instead have them as peer dependencies.

However until now, create-project has not actually configured them in `peerDependencies` correctly, which causes false positive ESLint errors from the `import/no-extraneous-dependencies` rule. These false positives were previously wallpapered over using `eslint-disable`, however that workaround was regressed in #949, and wasn't the correct fix anyway.

This wasn't caught in CI, since we did not test the combination of react-components with AirBnB, only with StandardJS.

Note: `eslint-plugin-imports` cache handling is fragile, so existing projects that have `peerDependencies` manually added will require the cache (`.eslintcache`) to be removed for the changes to be detected.

Fixes #1388.