### PR TITLE
Add helper functions for type-safety 

### DIFF
--- a/packages/neutrino/middleware.js
+++ b/packages/neutrino/middleware.js
@@ -1,6 +1,6 @@
-const createMiddlewareFactory = (factory) => factory;
+const createMiddlewareFactory = factory => factory;
 
-const createMiddleware = (middleware) => middleware;
+const createMiddleware = middleware => middleware;
 
 module.exports = {
   createMiddlewareFactory,

--- a/packages/neutrino/middleware.js
+++ b/packages/neutrino/middleware.js
@@ -1,0 +1,8 @@
+const createMiddlewareFactory = (factory) => factory;
+
+const createMiddleware = (middleware) => middleware;
+
+module.exports = {
+  createMiddlewareFactory,
+  createMiddleware,
+};


### PR DESCRIPTION
These functions are just the identity function. Its only purpose is to enable a good typespec and inline documentation in editors.

Since we removed the magic around loading middlewares this will enable some documentation from type specs in the editors when they import the middlewares.

I had been using this and I saw would be a good idea to share with you, I totally understand that we don't need this since could be solved differently.

```ts
export type NeutrinoMiddleware = (neutrino: Neutrino) => Neutrino;

export type NeutrinoMiddlewareFactory<T> = (
  options: T
) => (neutrino: Neutrino) => Neutrino;

export interface Neutrino {
  // ...
  use(middleware: NeutrinoMiddleware): void;
}
```

### Usage

```ts
// mymiddleware.ts

import { createMiddlewareFactory } from 'neutrino/middleware';

export const inlineChunkHtml = createMiddlewareFactory<InlineChunkHtmlOptions>(options => neutrino => {
   // ...
});
```

### Followup

- [ ] Update documentation
- [ ] Add TypeScript typespec

#### Inspiration

https://github.com/mui-org/material-ui/blob/ede30a5a0af518e780414bd853b93bb275863f48/packages/material-ui-styles/src/createStyles/createStyles.js#L1

https://material-ui.com/styles/api/#createstyles-styles-styles