### PR TITLE
Add back 'v' prefix to version output by print-version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint --no-eslintrc --config ./.eslintrc.js --cache --report-unused-disable-directives --format codeframe --ext js,jsx .",
     "prettier:check": "prettier --ignore-path .eslintignore --check \"**/*.{css,html,js,jsx,json,md,yaml,yml}\"",
     "prettier:fix": "prettier --ignore-path .eslintignore --write \"**/*.{css,html,js,jsx,json,md,yaml,yml}\"",
-    "print-version": "node -p \"require('./lerna.json').version\"",
+    "print-version": "node -p \"'v' +require('./lerna.json').version\"",
     "release:prepare": "lerna version && prettier --write lerna.json && yarn changelog",
     "release:commit": "git commit --all --message $(yarn -s print-version) --edit",
     "release:tag": "git tag $(yarn -s print-version) && git push upstream $(yarn -s print-version)",


### PR DESCRIPTION
So that the version used for commit messages and Git tags for new releases is of form `vN.N.N` not `N.N.N`, for consistency with previous releases. The 'v' was inadvertently removed as part of #1372.