### PR TITLE
Fix wrong function name in documentation example

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -143,7 +143,7 @@ module.exports = (additionalEnvs = []) => (neutrino) => {
 const envLoader = require('neutrino-middleware-env-loader');
 
 module.exports = neutrino => {
-  neutrino.use(env(['SECRET_KEY']));
+  neutrino.use(envLoader(['SECRET_KEY']));
   neutrino.use(/* next middleware */);
   neutrino.use(/* next middleware */)
 };


### PR DESCRIPTION
The function that should have been called should have been the one defined right before `envLoader` and not `env`. 

Great tool btw. I find the build process of projects using npm quite complex, so anything that aims at simplifying it is welcome on my end.