### PR TITLE
Docs: Add v8 to v9 migration instructions for WebWorkers

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -368,8 +368,31 @@ object using the [options here](https://webpack.js.org/configuration/dev-server/
 - **BREAKING CHANGE** `@neutrinojs/web` and its dependent middleware no longer support
 `style.extract` being set to `true` [#1221](https://github.com/neutrinojs/neutrino/pull/1221).
 Override `style.extract.enabled` instead.
-- **BREAKING CHANGE** `@neutrinojs/web` and its dependent middleware no longer include `worker-loader` for automatically
-loading `*.worker.js` files [#1069](https://github.com/neutrinojs/neutrino/pull/1069).
+- **BREAKING CHANGE** `@neutrinojs/web`, its dependent middleware, and `@neutrinojs/library` no longer include
+`worker-loader` for automatically loading `*.worker.js` files [#1069](https://github.com/neutrinojs/neutrino/pull/1069).
+To add back support use a `.neutrinorc.js` configuration similar to:
+
+```js
+module.exports = {
+  use: [
+    // ...
+    (neutrino) => {
+      neutrino.config.output
+        .globalObject('this') // will prevent `window`
+      .end()
+      .module
+        .rule('worker')
+          .test(neutrino.regexFromExtensions(['worker.js']))
+          .use('worker')
+            .loader(require.resolve('worker-loader'))
+            .options({
+              // See: https://github.com/webpack-contrib/worker-loader#options
+            });
+    }
+  ]
+};
+```
+
 - **BREAKING CHANGE** The loading order for `config.resolve.extensions` has been rearranged to be closer in parity to
 what webpack has configured by default [#1080](https://github.com/neutrinojs/neutrino/pull/1080).
 - **BREAKING CHANGE** The tests directory is now additionally linted by default with `@neutrinojs/eslint` and its
@@ -392,7 +415,7 @@ check and test your project to ensure proper functionality.
 // .neutrinorc.js
 module.exports = {
   use: [
-    '@neutrinojs/web',
+    // ...
     (neutrino) => {
       if (process.env.NODE_ENV === 'production') {
         neutrino.config.plugin('manifest')


### PR DESCRIPTION
This is #1467 rebased on master and with a couple of tweaks.

I tried to make the changes as follow-up commits to that PR (using [this](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/committing-changes-to-a-pull-request-branch-created-from-a-fork) GitHub feature), but was getting permission errors - I believe since the repo owner isn't the same as the PR author - so had to split this out to a new PR (I've kept the commit author info).

Closes #1467.