### PR TITLE
Exclude all extra options of `babel-loader`

### DIFF
--- a/packages/jest/src/index.js
+++ b/packages/jest/src/index.js
@@ -24,7 +24,7 @@ module.exports = (options = {}) => (neutrino) => {
       'cacheDirectory',
       'cacheCompression',
       'cacheIdentifier',
-      'customize'
+      'customize',
     ];
     const compileRule = neutrino.config.module.rules.get('compile');
     const babelOptions = compileRule

--- a/packages/jest/src/index.js
+++ b/packages/jest/src/index.js
@@ -20,9 +20,10 @@ module.exports = (options = {}) => (neutrino) => {
   }
 
   neutrino.register('jest', (neutrino) => {
+    const babelLoaderOptionsNames = ['cacheDirectory', 'cacheCompression', 'cacheIdentifier', 'customize'];
     const compileRule = neutrino.config.module.rules.get('compile');
     const babelOptions = compileRule
-      ? omit(compileRule.use('babel').get('options'), ['cacheDirectory'])
+      ? omit(compileRule.use('babel').get('options'), babelLoaderOptionsNames)
       : {};
     // Any parts of the babel config that are not serializable will be omitted, however
     // that also occurs when passing to the custom transformer using `globals` instead.

--- a/packages/jest/src/index.js
+++ b/packages/jest/src/index.js
@@ -20,7 +20,12 @@ module.exports = (options = {}) => (neutrino) => {
   }
 
   neutrino.register('jest', (neutrino) => {
-    const babelLoaderOptionsNames = ['cacheDirectory', 'cacheCompression', 'cacheIdentifier', 'customize'];
+    const babelLoaderOptionsNames = [
+      'cacheDirectory',
+      'cacheCompression',
+      'cacheIdentifier',
+      'customize'
+    ];
     const compileRule = neutrino.config.module.rules.get('compile');
     const babelOptions = compileRule
       ? omit(compileRule.use('babel').get('options'), babelLoaderOptionsNames)

--- a/packages/jest/test/jest_test.js
+++ b/packages/jest/test/jest_test.js
@@ -2,6 +2,7 @@ import test from 'ava';
 import airbnbPreset from '../../airbnb';
 import eslintPreset from '../../eslint';
 import reactPreset from '../../react';
+import compileMiddleware from '../../compile-loader';
 import Neutrino from '../../neutrino/Neutrino';
 import neutrino from '../../neutrino';
 
@@ -11,6 +12,7 @@ const originalNodeEnv = process.env.NODE_ENV;
 test.afterEach(() => {
   // Restore the original NODE_ENV after each test (which Ava defaults to 'test').
   process.env.NODE_ENV = originalNodeEnv;
+  process.env.JEST_BABEL_OPTIONS = undefined;
 });
 
 test('loads middleware', (t) => {
@@ -110,4 +112,36 @@ test('configures moduleFileExtensions correctly', (t) => {
     'js',
     'json',
   ]);
+});
+
+test('exposes babel config', (t) => {
+  const api = new Neutrino();
+  api.use(compileMiddleware({
+    cacheDirectory: true,
+    cacheCompression: false,
+    cacheIdentifier: false,
+    customize: true
+  }));
+  api.use(mw());
+  
+  const babelOptions = JSON.parse(process.env.JEST_BABEL_OPTIONS)
+  t.truthy(babelOptions);
+});
+test('exposes babel config without babel-loader specific options', (t) => {
+  const api = new Neutrino();
+  api.use(compileMiddleware({
+    babel: {
+      cacheDirectory: true,
+      cacheCompression: false,
+      cacheIdentifier: false,
+      customize: true
+    }
+  }));
+  api.use(mw());
+  
+  const babelOptions = JSON.parse(process.env.JEST_BABEL_OPTIONS)
+  t.false('cacheDirectory' in babelOptions);
+  t.false('cacheCompression' in babelOptions);
+  t.false('cacheIdentifier' in babelOptions);
+  t.false('customize' in babelOptions);
 });

--- a/packages/jest/test/jest_test.js
+++ b/packages/jest/test/jest_test.js
@@ -114,7 +114,7 @@ test('configures moduleFileExtensions correctly', (t) => {
   ]);
 });
 
-test("exposes babel config", (t) => {
+test('exposes babel config', (t) => {
   const api = new Neutrino();
   api.use(
     compileMiddleware({
@@ -122,7 +122,7 @@ test("exposes babel config", (t) => {
       cacheCompression: false,
       cacheIdentifier: false,
       customize: true,
-    })
+    }),
   );
   api.use(mw());
 
@@ -130,7 +130,7 @@ test("exposes babel config", (t) => {
   t.truthy(babelOptions);
 });
 
-test("exposes babel config without babel-loader specific options", (t) => {
+test('exposes babel config without babel-loader specific options', (t) => {
   const api = new Neutrino();
   api.use(
     compileMiddleware({
@@ -140,13 +140,13 @@ test("exposes babel config without babel-loader specific options", (t) => {
         cacheIdentifier: false,
         customize: true,
       },
-    })
+    }),
   );
   api.use(mw());
 
   const babelOptions = JSON.parse(process.env.JEST_BABEL_OPTIONS);
-  t.false("cacheDirectory" in babelOptions);
-  t.false("cacheCompression" in babelOptions);
-  t.false("cacheIdentifier" in babelOptions);
-  t.false("customize" in babelOptions);
+  t.false('cacheDirectory' in babelOptions);
+  t.false('cacheCompression' in babelOptions);
+  t.false('cacheIdentifier' in babelOptions);
+  t.false('customize' in babelOptions);
 });

--- a/packages/jest/test/jest_test.js
+++ b/packages/jest/test/jest_test.js
@@ -114,34 +114,39 @@ test('configures moduleFileExtensions correctly', (t) => {
   ]);
 });
 
-test('exposes babel config', (t) => {
+test("exposes babel config", (t) => {
   const api = new Neutrino();
-  api.use(compileMiddleware({
-    cacheDirectory: true,
-    cacheCompression: false,
-    cacheIdentifier: false,
-    customize: true
-  }));
-  api.use(mw());
-  
-  const babelOptions = JSON.parse(process.env.JEST_BABEL_OPTIONS)
-  t.truthy(babelOptions);
-});
-test('exposes babel config without babel-loader specific options', (t) => {
-  const api = new Neutrino();
-  api.use(compileMiddleware({
-    babel: {
+  api.use(
+    compileMiddleware({
       cacheDirectory: true,
       cacheCompression: false,
       cacheIdentifier: false,
-      customize: true
-    }
-  }));
+      customize: true,
+    })
+  );
   api.use(mw());
-  
-  const babelOptions = JSON.parse(process.env.JEST_BABEL_OPTIONS)
-  t.false('cacheDirectory' in babelOptions);
-  t.false('cacheCompression' in babelOptions);
-  t.false('cacheIdentifier' in babelOptions);
-  t.false('customize' in babelOptions);
+
+  const babelOptions = JSON.parse(process.env.JEST_BABEL_OPTIONS);
+  t.truthy(babelOptions);
+});
+
+test("exposes babel config without babel-loader specific options", (t) => {
+  const api = new Neutrino();
+  api.use(
+    compileMiddleware({
+      babel: {
+        cacheDirectory: true,
+        cacheCompression: false,
+        cacheIdentifier: false,
+        customize: true,
+      },
+    })
+  );
+  api.use(mw());
+
+  const babelOptions = JSON.parse(process.env.JEST_BABEL_OPTIONS);
+  t.false("cacheDirectory" in babelOptions);
+  t.false("cacheCompression" in babelOptions);
+  t.false("cacheIdentifier" in babelOptions);
+  t.false("customize" in babelOptions);
 });


### PR DESCRIPTION
We should extract only Babel options to Jest but not `babel-loader` options as it has some extra options that can break Babel configuration validation. For example like this

```
Unknown option: .cacheCompression. Check out https://babeljs.io/docs/en/babel-core/#options for more information about options.
```
![jest](https://user-images.githubusercontent.com/673144/79039523-77299900-7bea-11ea-83ff-cb723e542ae4.jpg)

Neutrino core presets don't use such options but other authors may use them and `@neutrinojs/jest` will fail