### PR TITLE
Test against Node 14 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 cache: yarn
 node_js:
   - '10'
-  - '13'
+  - '14'
 env:
   - CREATE_PROJECT_YARN=true
   - CREATE_PROJECT_YARN=false


### PR DESCRIPTION
Since it's replacing Node 13 as latest current:
https://nodejs.org/en/about/releases/

Node 13 has been removed since it's EOL 1st June, and testing against Node {10,12,14} pretty much guarantees Node 13 support anyway.