### PR TITLE
Update Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,9 +3,8 @@
     "config:base",
     ":maintainLockFilesWeekly",
     ":prNotPending",
-    ":semanticCommitsDisabled",
-    ":unpublishSafe"
+    ":semanticCommitsDisabled"
   ],
-  "reviewers": ["neutrinojs/core-contributors"],
+  "reviewers": ["team:neutrinojs/core-contributors"],
   "pinVersions": false
 }


### PR DESCRIPTION
* Remove [`unpublishSafe`](https://docs.renovatebot.com/configuration-options/#unpublishsafe) since whilst the feature can be useful for end applications that pin to specific versions and are deployed soon after upgrading dependencies, it offers much less value for libraries and means I have to wait for eg the ESLint 7 PR for another day.
* Adjust the [`reviewers`](https://docs.renovatebot.com/configuration-options/#reviewers) value to use the `team:` prefix as now instructed in the docs (they didn't use to say to use it).