### PR TITLE
jest: Fix configuration of Webpack aliases

### DIFF
--- a/packages/jest/src/index.js
+++ b/packages/jest/src/index.js
@@ -63,7 +63,7 @@ module.exports = (options = {}) => (neutrino) => {
         moduleNameMapper: Object.keys(aliases).reduce(
           (mapper, key) => ({
             ...mapper,
-            [`^${key}$`]: `${getFinalPath(aliases[key])}$1`,
+            [`^${key}$`]: `${getFinalPath(aliases[key])}`,
           }),
           {
             [extensionsToNames(media)]: require.resolve('./file-mock'),

--- a/packages/jest/test/jest_test.js
+++ b/packages/jest/test/jest_test.js
@@ -161,7 +161,7 @@ test('configures webpack aliases in moduleNameMapper correctly', (t) => {
   const config = api.outputHandlers.get('jest')(api);
 
   t.true(
-    Object.entries(config.moduleNameMapper).some(function ([key, alias]) {
+    Object.entries(config.moduleNameMapper).some(([key, alias]) => {
       return key === '^react$' && alias === reactPath;
     }),
   );

--- a/packages/jest/test/jest_test.js
+++ b/packages/jest/test/jest_test.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import test from 'ava';
 import airbnbPreset from '../../airbnb';
 import eslintPreset from '../../eslint';
@@ -149,4 +150,19 @@ test('exposes babel config without babel-loader specific options', (t) => {
   t.false('cacheCompression' in babelOptions);
   t.false('cacheIdentifier' in babelOptions);
   t.false('customize' in babelOptions);
+});
+
+test('configures webpack aliases in moduleNameMapper correctly', (t) => {
+  const api = new Neutrino();
+  const reactPath = path.resolve(path.join('node_modules', 'react'));
+  api.use(reactPreset());
+  api.use(mw());
+  api.config.resolve.alias.set('react', reactPath);
+  const config = api.outputHandlers.get('jest')(api);
+
+  t.true(
+    Object.entries(config.moduleNameMapper).some(function ([key, alias]) {
+      return key === '^react$' && alias === reactPath;
+    }),
+  );
 });


### PR DESCRIPTION
If we configure alias to React in Webpack which is required by `react-hot-loader` the Jest tests fail with an error 
```bash
Configuration error:

    Could not locate module react mapped as:
    C:\Projects\project\node_modules\react$1.

    Please check your configuration for these entries:
    {
      "moduleNameMapper": {
        "/^react$/": "C:\Projects\project\node_modules\react$1"
      },
      "resolver": undefined
    }

    > 1 | import React from 'react';
        | ^
      2 | import PropTypes from 'prop-types';
```

**To reproduce this** we need to add something like that to the Webpack aliases configuration

```js
neutrino.config.resolve.alias.set('react', path.resolve(path.join(projectNodeModulesPath, 'react')))
```

And import any JSX component in tests.

I am curios why we need this `$1` at the end. It only makes sense if the key contains angle brackets `()` like:

*Example from Jest docs* 
```json
"module_name_(.*)": "<rootDir>/substituted_module_$1.js",
"assets/(.*)": [
      "<rootDir>/images/$1",
      "<rootDir>/photos/$1",
      "<rootDir>/recipes/$1"
]
```


But we know that we can't ever have angle brackets in the alias key. 

The issue can be fixed by removing `$1` placeholder

Fixes #1552.