### PR TITLE
Travis: Switch from Xenial to Focal build image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: focal
 language: node_js
 cache: yarn
 node_js:


### PR DESCRIPTION
Since the new image contains more up to date tools and is slimmer.