### PR TITLE
jest: Support overriding moduleNameMapper via preset options

### DIFF
--- a/packages/jest/src/index.js
+++ b/packages/jest/src/index.js
@@ -67,6 +67,7 @@ module.exports = (options = {}) => (neutrino) => {
             [`^${key}$`]: `${getFinalPath(aliases[key])}`,
           }),
           {
+            ...options.moduleNameMapper,
             [extensionsToNames(media)]: require.resolve('./file-mock'),
             [extensionsToNames(style)]: require.resolve('./style-mock'),
           },

--- a/packages/jest/test/jest_test.js
+++ b/packages/jest/test/jest_test.js
@@ -174,3 +174,13 @@ test('configures webpack aliases in moduleNameMapper correctly', (t) => {
     }),
   );
 });
+
+test('gives custom moduleNameMapper entries priority over default entries', (t) => {
+  const api = new Neutrino();
+  api.use(mw({ moduleNameMapper: { foo: 'bar' } }));
+  const config = api.outputHandlers.get('jest')(api);
+  const moduleNameMapper = Object.entries(config.moduleNameMapper);
+
+  t.true(moduleNameMapper.length > 1);
+  t.deepEqual(moduleNameMapper[0], ['foo', 'bar']);
+});


### PR DESCRIPTION
As explained in #1650, this small change makes it possible for users to override default configuration for Jest's `moduleNameMapper`.

Specifically, this is important for me so that I can integrate [svgr](https://www.npmjs.com/package/@svgr/webpack) into my project correctly;

```js
    jest({
      moduleNameMapper: {
        '\\.svg$': '<rootDir>/mocks/svgr.js',
      },
    }),
```

(without this change, the above `.svg` rule is ignored due to the built-in rule taking priority; Jest follows the key ordering of the entries in `moduleNameMapper`).

I do not expect this to break anybody's config unless they had it misconfigured to begin with. If it does break for anybody, the fix is to remove any user-provided config that was previously being ignored.